### PR TITLE
Fix format:uncompressed only leaving one directory uncompressed

### DIFF
--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -240,7 +240,7 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
         """
         Archive the given directory.
         """
-        if properties and properties.pop('format', None) == 'uncompressed':
+        if properties and properties.get('format', None) == 'uncompressed':
             # recursively find all files in dir and add
             # each one, passing any properties
             find_output_file = f"{str(uuid.uuid4())}.out"

--- a/tests/test-files/test-general.yaml
+++ b/tests/test-files/test-general.yaml
@@ -140,3 +140,18 @@ steps:
       artifacts:
         'bob': {format: 'uncompressed', prop1: 'hello'}
         'bob/bob2':
+
+  setup-uncompress-dirs:
+    run:
+      image: {{ DOCKER_REGISTRY }}/centos:8
+      cmds:
+        - 'mkdir -p parent/dir1; echo "test" > parent/dir1/file1.txt; echo "test" > parent/dir1/file1.txt'
+        - 'mkdir -p parent/dir2; echo "test" > parent/dir1/file2.txt; echo "test" > parent/dir2/file1.txt'
+        - 'mkdir -p parent/dir3; echo "test" > parent/dir1/file3.txt; echo "test" > parent/dir3/file1.txt'
+      artifacts:
+        'parent/*': {format: 'uncompressed'}
+
+  test-uncompressed-dirs:
+    run:
+      image: {{ DOCKER_REGISTRY }}/centos:8
+      cmd: 'if [ $(ls -laR /artifacts/setup-uncompress-dirs/ | grep tar.gz | wc -l) != 0 ]; then exit 1; fi'


### PR DESCRIPTION
## Description

The format:uncompressed property was being removed after the first directory was added to artifacts

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.