### PR TITLE
Add temp dir to docker builder, move to rocky linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -610,9 +610,8 @@ the run step:
         <or>
         platform: linux/arm64/v8 # an apple m1 architecture
 
-        # systemd doesn't play well with docker, but our base development
-        # environment is transitioning to Cent 7, which uses systemd.
-        # Use this setting to tell buildrunner to set the necessary docker
+        # systemd does not play well with docker typically, but you can
+        # use this setting to tell buildrunner to set the necessary docker
         # flags to get systemd to work properly:
         # - /usr/sbin/init needs to run as pid 1
         # - /sys/fs/cgroup needs to be mounted as readonly
@@ -813,7 +812,7 @@ from the specified Docker image and archives the given artifacts:
       run:
         image: myimages/image-with-cmd:latest
         artifacts:
-          omtr_tmp/artifacts/*.x86_64.rpm: {platform: 'centos-6-x86_64'}
+          build/artifacts/*.x86_64.rpm: {platform: 'centos-8-x86_64'}
 
 This example builds a custom image using a build context and Dockerfile in a
 subdirectory of the project, then uses the resulting image for the run
@@ -826,7 +825,7 @@ container:
       build: package-container
       run:
         artifacts:
-          omtr_tmp/artifacts/*.x86_64.rpm:
+          build/artifacts/*.x86_64.rpm:
 
 This example uses one step to create a package and another to run an
 integration test:

--- a/buildrunner/docker/builder.py
+++ b/buildrunner/docker/builder.py
@@ -32,16 +32,18 @@ class DockerBuilder:  # pylint: disable=too-many-instance-attributes
             dockerd_url=None,
             timeout=None,
             docker_registry=None,
+            temp_dir=None,
     ):  # pylint: disable=too-many-arguments
         self.path = path
         self.inject = inject
+        self.temp_dir = temp_dir
         self.dockerfile = None
         self.cleanup_dockerfile = False
         if dockerfile:
             if os.path.exists(dockerfile):
                 self.dockerfile = dockerfile
             else:
-                df_file = tempfile.NamedTemporaryFile(delete=False)
+                df_file = tempfile.NamedTemporaryFile(delete=False, dir=self.temp_dir)
                 try:
                     df_file.write(dockerfile.encode('utf-8'))
                     self.cleanup_dockerfile = True
@@ -86,7 +88,7 @@ class DockerBuilder:  # pylint: disable=too-many-instance-attributes
         if buildargs is None:
             buildargs = {}
         # create our own tar file, injecting the appropriate paths
-        _fileobj = tempfile.NamedTemporaryFile()
+        _fileobj = tempfile.NamedTemporaryFile(dir=self.temp_dir)
         tfile = tarfile.open(mode='w', fileobj=_fileobj)
         if self.path:
             tfile.add(self.path, arcname='.')

--- a/buildrunner/sshagent/SSHAgentProxyImage/Dockerfile
+++ b/buildrunner/sshagent/SSHAgentProxyImage/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKER_REGISTRY
-FROM $DOCKER_REGISTRY/centos:8
+FROM $DOCKER_REGISTRY/rockylinux:8.5
 
 RUN yum clean all; yum -y install openssh-server socat
 RUN mkdir /var/run/sshd; mkdir /ssh-agent

--- a/tests/runservicecontainer/Dockerfile
+++ b/tests/runservicecontainer/Dockerfile
@@ -1,3 +1,3 @@
 ARG DOCKER_REGISTRY
-FROM $DOCKER_REGISTRY/centos:8
+FROM $DOCKER_REGISTRY/rockylinux:8.5
 RUN yum -y install curl

--- a/tests/test-files/test-general.yaml
+++ b/tests/test-files/test-general.yaml
@@ -22,7 +22,7 @@ steps:
 
   artifacts:
     run:
-      image: {{ DOCKER_REGISTRY}}/centos:8
+      image: {{ DOCKER_REGISTRY}}/rockylinux:8.5
       cmds: [
         'echo "test" > test.txt',
         'echo "success" > success.comment',
@@ -40,7 +40,7 @@ steps:
   build-and-service-containers:
     build:
       dockerfile: |
-        FROM {{ DOCKER_REGISTRY }}/centos:8
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
         RUN yum -y install curl
     run:
       services:
@@ -58,9 +58,10 @@ steps:
   run-docker:
     build:
       dockerfile: |
-        FROM {{ DOCKER_REGISTRY }}/centos:8
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
 
-        # update yum and install docker-ce from docker repo, since centos8 doesn't support docker anymore
+        # update yum and install docker-ce from docker repo, since centos/rockylinux 8
+        # does not provide docker in its repos anymore
         RUN yum -y update && yum clean all
         RUN yum -y install yum-utils
         RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
@@ -75,14 +76,14 @@ steps:
         'env',
         'systemctl enable docker',
         'docker info',
-        'docker run centos:8 hostname',
-        'docker run --volumes-from $BUILDRUNNER_BUILD_CONTAINER centos:8 touch /bob/test2',
+        'docker run rockylinux:8.5 hostname',
+        'docker run --volumes-from $BUILDRUNNER_BUILD_CONTAINER rockylinux:8.5 touch /bob/test2',
         'ls -al /bob',
       ]
 
   run-post-build-path:
     run:
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       cmd: 'echo "hello" > /hello.txt'
       post-build: tests/postbuildpath
     push:
@@ -90,7 +91,7 @@ steps:
 
   run-post-build-inline:
     run:
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       cmd: 'echo "hello" > /hello.txt'
       post-build:
         dockerfile: |
@@ -100,7 +101,7 @@ steps:
 
   run-post-build-inject:
     run:
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       cmd: 'echo "hello" > /hello.txt'
       post-build:
         # use a different container here to make sure inject overrides
@@ -113,7 +114,7 @@ steps:
 
   archive-container-config:
     run:
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       cmd: 'echo "create marathon config here"'
       artifacts:
         'marathon.config': {'marathon.config': 'releng/testmodule'}
@@ -131,7 +132,7 @@ steps:
 
   test-dir-archive:
     run:
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       cmds:
         - 'mkdir bob; echo "hello" > bob/file1.txt; echo "hello" > bob/file2.txt'
         - 'mkdir -p bob/bob2; echo "hello" > bob/bob2/file1.txt; echo "hello" > bob/bob2/file2.txt'

--- a/tests/test-files/test-ssh.yaml
+++ b/tests/test-files/test-ssh.yaml
@@ -2,7 +2,7 @@ steps:
   clone:
     build:
       dockerfile: |
-        FROM {{ DOCKER_REGISTRY }}/centos:8
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
         RUN yum install -y git-core openssh-clients && yum clean all
     run:
       ssh-keys: ['buildrunner-deploy']

--- a/tests/test-files/test-systemd.yaml
+++ b/tests/test-files/test-systemd.yaml
@@ -3,19 +3,19 @@
 steps:
 
   # Ensure the image is here so the next step always passes
-  ensure-centos8:
+  ensure-image-exists:
     run:
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       cmd:   /bin/true
-  # Remove the centos image
+  # Remove the image
   clean-images-1:
     run:
       image: {{ DOCKER_REGISTRY }}/docker:20.10-dind
-      cmd:   docker rmi -f {{ DOCKER_REGISTRY }}/centos:8
-  # Start up a container, it should NOT fail based on centos:8 not existing
+      cmd:   docker rmi -f {{ DOCKER_REGISTRY }}/rockylinux:8.5
+  # Start up a container, it should NOT fail based on rockylinux:8.5 not existing
   test-without-systemd:
     run:
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       cmd:   /bin/true
 
   # Same as above, but for a service container
@@ -27,19 +27,15 @@ steps:
     run:
       image: {{ DOCKER_REGISTRY }}/docker:20.10-dind
       pull:  false
-      cmd:   docker rmi -f {{ DOCKER_REGISTRY }}/centos:8 {{ DOCKER_REGISTRY }}/alpine:latest
+      cmd:   docker rmi -f {{ DOCKER_REGISTRY }}/rockylinux:8.5 {{ DOCKER_REGISTRY }}/alpine:latest
   test-service-without-systemd:
      run:
        services:
          s1:
            build:
              dockerfile: |
-               FROM {{ DOCKER_REGISTRY }}/centos:8
-               RUN						\
-                 set -eux;					\
-                 yum clean all;				\
-                 yum -y install python3-setuptools python3-pip;		\
-                 rm -rf /var/cache/yum
+               FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
+               RUN yum -y install python3-setuptools python3-pip && yum clean all
                LABEL BUILDRUNNER_SYSTEMD=1
            run:
              cmd: python3 -m http.server 8001
@@ -48,22 +44,29 @@ steps:
 
   # Ensure systemd init process is not running
   test-systemd-off:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
+        RUN yum install -y procps-ng && yum clean all
     run:
-       image: {{ DOCKER_REGISTRY }}/centos:8
        systemd: false
        cmd: ps -p 1 -o cmd | tail -1 | grep -v /usr/sbin/init
 
   # Ensure systemd init process is running
   test-systemd-on:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
+        RUN yum install -y procps-ng && yum clean all
     run:
-       image: {{ DOCKER_REGISTRY }}/centos:8
        systemd: true
        cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
 
   test-systemd-on-built:
     build:
       dockerfile: |
-        FROM {{ DOCKER_REGISTRY }}/centos:8
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
+        RUN yum install -y procps-ng && yum clean all
         LABEL BUILDRUNNER_SYSTEMD=1
     run:
       cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
@@ -72,7 +75,8 @@ steps:
   test-systemd-off-built-{{ v }}:
     build:
       dockerfile: |
-        FROM {{ DOCKER_REGISTRY }}/centos:8
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
+        RUN yum install -y procps-ng && yum clean all
         LABEL BUILDRUNNER_SYSTEMD={{ v }}
     run:
       cmd: ps -p 1 -o cmd | tail -1 | grep -v /usr/sbin/init
@@ -86,15 +90,11 @@ steps:
         s1:
           build:
             dockerfile: |
-              FROM {{ DOCKER_REGISTRY }}/centos:8
-              RUN						\
-                set -eux;					\
-                yum clean all;				\
-                yum -y install python3-setuptools python3-pip;		\
-                rm -rf /var/cache/yum
+              FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
+              RUN yum -y install python3 procps-ng && yum clean all
               LABEL BUILDRUNNER_SYSTEMD=1
           systemd: true
           cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init && python3 -m http.server 8001
-      image: {{ DOCKER_REGISTRY }}/centos:8
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       pull: false
       cmd: curl http://s1:8001 1>/dev/null 2>&1

--- a/tests/webservicecontainer/Dockerfile
+++ b/tests/webservicecontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG DOCKER_REGISTRY
-FROM $DOCKER_REGISTRY/centos:8
+FROM $DOCKER_REGISTRY/rockylinux:8.5
 RUN						\
     set -eux;					\
     yum clean all;				\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the temporary directory configured in global config (or via env var). 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There is a temp_dir configuration property in the global config, but it is not respected for certain usages, especially building the source docker image which can be quite large. After modifying this, I noticed that centos:8 images no longer work properly due its deadness. Really, it's very dead. I ported to rockylinux 8 instead which is bug-for-bug compatible.

## How Has This Been Tested?

It is a non-invasive change that will need to be tested by the person who first saw signs of the bug. The build will test the rockylinux portions of the changes.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.