### PR TITLE
Add VCSINFO_RELEASE and update docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -456,7 +456,7 @@ every run container:
 
 :``BUILDRUNNER_BUILD_NUMBER``: the build number
 :``BUILDRUNNER_BUILD_ID``: a unique id identifying the build (includes vcs and build number
-                           information)
+                           information), e.g. "main-1791.Ia09cc5.M0-1661374484"
 :``BUILDRUNNER_BUILD_DOCKER_TAG``: identical to ``BUILDRUNNER_BUILD_ID`` but formatted for
                                    use as a Docker tag
 :``BUILDRUNNER_BUILD_TIME``: the "unix" time or "epoch" time of the build (in seconds)
@@ -468,13 +468,14 @@ every run container:
 :``BUILDRUNNER_INVOKE_UID``: The UID of the user that invoked Buildrunner
 :``BUILDRUNNER_INVOKE_GROUP``: The group of the user that invoked Buildrunner
 :``BUILDRUNNER_INVOKE_GID``: The GID (group ID) of the user that invoked Buildrunner
-:``VCSINFO_NAME``: the VCS repository name without a path
-:``VCSINFO_BRANCH``: the VCS branch
-:``VCSINFO_NUMBER``: the VCS commit number
-:``VCSINFO_ID``: the VCS commit id
-:``VCSINFO_SHORT_ID``: the VCS short commit id
+:``VCSINFO_NAME``: the VCS repository name without a path, "my-project"
+:``VCSINFO_BRANCH``: the VCS branch, e.g. "main"
+:``VCSINFO_NUMBER``: the VCS commit number, e.g. "1791"
+:``VCSINFO_ID``: the VCS commit id, e.g. "a09cc5c407af605b57a0f16b73f896873bb74759"
+:``VCSINFO_SHORT_ID``: the VCS short commit id, e.g. "a09cc5c"
+:``VCSINFO_RELEASE``: the VCS branch state, .e.g. "1791.Ia09cc5.M0"
 :``VCSINFO_MODIFIED``: the last file modification timestamp if local changes have been made and not
-                       committed to the source VCS repository
+                       committed to the source VCS repository, e.g. "1661373883"
 
 The following volumes are created within run containers:
 

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -98,6 +98,7 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
             'VCSINFO_ID': str(self.vcs.id),
             'VCSINFO_SHORT_ID': str(self.vcs.id)[:7],
             'VCSINFO_MODIFIED': str(self.vcs.modified),
+            'VCSINFO_RELEASE': str(self.vcs.release),
             'BUILDRUNNER_STEPS': self.steps_to_run,
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We did not currently expose the VCSINFO_RELEASE variable, even though vcsinfo provides it. This adds support for it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I needed the VCSINFO_RELEASE variable accessed from a built component.

## How Has This Been Tested?

I installed the latest code and ensured it was present.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.