### PR TITLE
Add support for global env vars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,15 @@ they are used when put into the global configuration file:
 
 .. code:: yaml
 
+  # The 'env' global configuration may be used to set environment variables
+  # available to all buildrunner runs that load this config file. Env vars do
+  # not need to begin with a prefix to be included in this list (i.e.
+  # BUILDRUNNER_ prefix is not needed for variables listed here).
+  env:
+    ENV_VAR1: 'value1'
+    # Values must always be strings
+    ENV_VAR2: 'true''
+
   # The 'build-servers' global configuration consists of a map where each key
   # is a server user@host string and the value is a list of host aliases that
   # map to the server. This allows builders to configure Buildrunner to talk to

--- a/tests/config-files/dot-buildrunner.yaml
+++ b/tests/config-files/dot-buildrunner.yaml
@@ -26,3 +26,8 @@ local-files:
 # The 'caches-root' global configuration specifies the directory to use for
 # build caches. The default directory is ~/.buildrunner/caches.
 caches-root: ~/.buildrunner/caches
+
+# The 'env' global configuration specifies env vars that are available in
+# buildrunner scripts
+env:
+  GLOBAL_VAR1: 'value1'

--- a/tests/test-files/test-env-vars.yaml
+++ b/tests/test-files/test-env-vars.yaml
@@ -1,0 +1,15 @@
+steps:
+  test:
+    run:
+        image: {{ DOCKER_REGISTRY }}/busybox:latest
+        env:
+          LOCAL_VAR1: 'value1'
+          LOCAL_FROM_GLOBAL_VAR1: "{{ GLOBAL_VAR1 }}"
+        cmd: |
+          if [ "$LOCAL_VAR1" == "value1" -a "$LOCAL_FROM_GLOBAL_VAR1" == "value1" ]; then
+            echo "Variables validated successfully"
+          else
+            echo "Missing global or local variables"
+            exit 1
+          fi
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds support for global environment variables in the buildrunner global config file. 

## Related Issue

n/a

## Motivation and Context

This allows supporting additional use cases such as providing secret credentials via env vars to every buildrunner build on a system. It is currently needed for improving a buildrunner yaml file that is used across many builds on local and build server systems.

## How Has This Been Tested?

I installed the code locally and tested the functionality. I also added a functional test via a buildrunner test file.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.