### PR TITLE
Add timeout to file locking around saving and restoring caches.

### DIFF
--- a/buildrunner/utils.py
+++ b/buildrunner/utils.py
@@ -380,7 +380,7 @@ def _acquire_flock_open(
 
     return lock_file_obj
 
-def acquire_flock_open_read_binary_(
+def acquire_flock_open_read_binary(
         lock_file: str,
         logger: ContainerLogger,
         timeout_seconds: float = LOCK_TIMEOUT_SECONDS) -> io.BufferedReader:

--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,4 @@ vcsinfo>=2.1.105
 graphlib-backport>=1.0.3
 # Needed for python 3.6
 typing-extensions<4.2.0
+timeout-decorator>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,6 +93,8 @@ six==1.16.0
     #   paramiko
 smmap==5.0.0
     # via gitdb
+timeout-decorator==0.5.0
+    # via -r requirements.in
 tqdm==4.64.0
     # via twine
 twine==3.2.0

--- a/tests/test_utils_flock.py
+++ b/tests/test_utils_flock.py
@@ -5,7 +5,7 @@ from unittest import mock
 from os import path
 
 import pytest
-from buildrunner.utils import ContainerLogger, FailureToAcquireLockException, acquire_read_binary_flock, acquire_write_binary_flock, release_flock
+from buildrunner.utils import ContainerLogger, FailureToAcquireLockException, acquire_flock_open_read_binary_, acquire_flock_open_write_binary, release_flock
 
 @pytest.fixture(name="mock_logger")
 def fixture_mock_logger():
@@ -19,9 +19,9 @@ def get_and_hold_lock(lock_file, sleep_seconds, exclusive=True, timeout_seconds=
         mock_logger = mock.create_autospec(ContainerLogger)
         mock_logger.write.side_effect = lambda message: print(message.strip())
         if exclusive:
-            fd = acquire_write_binary_flock(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds)
+            fd = acquire_flock_open_write_binary(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds)
         else:
-            fd = acquire_read_binary_flock(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds)
+            fd = acquire_flock_open_read_binary_(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds)
         assert fd is not None
         time.sleep(sleep_seconds)
     finally:
@@ -32,7 +32,7 @@ def test_flock_aquire1(mock_logger):
         try:
             fd = None
             lock_file = f'{tmp_dir_name}/mylock.file'
-            fd = acquire_write_binary_flock(lock_file=lock_file, logger=mock_logger, timeout_seconds=1.0)
+            fd = acquire_flock_open_write_binary(lock_file=lock_file, logger=mock_logger, timeout_seconds=1.0)
             assert fd is not None
 
         finally:
@@ -50,7 +50,7 @@ def test_flock_exclusive_aquire(mock_logger):
             p.start()
             time.sleep(1)
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
+                fd = acquire_flock_open_write_binary(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is None
             p.join()
 
@@ -59,7 +59,7 @@ def test_flock_exclusive_aquire(mock_logger):
             p.start()
             time.sleep(1)
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
+                fd = acquire_flock_open_write_binary(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is None
             p.join()
 
@@ -68,7 +68,7 @@ def test_flock_exclusive_aquire(mock_logger):
             p.start()
             time.sleep(1)
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_read_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
+                fd = acquire_flock_open_read_binary_(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is None
             p.join()
 
@@ -85,7 +85,7 @@ def test_flock_release(mock_logger):
             p = Process(target=get_and_hold_lock, args=(lock_file, 2))
             p.start()
             time.sleep(1)
-            fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=2.0)
+            fd = acquire_flock_open_write_binary(lock_file, mock_logger, timeout_seconds=2.0)
             assert fd is not None
             p.join()
         finally:
@@ -106,7 +106,7 @@ def test_flock_aquire_exlusive_timeout(mock_logger):
             timeout_seconds = 5
             start_time = time.time()
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
+                fd = acquire_flock_open_write_binary(lock_file, mock_logger, timeout_seconds=timeout_seconds)
             duration_seconds = time.time() - start_time
             tolerance_seconds = 0.6
             assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
@@ -121,7 +121,7 @@ def test_flock_aquire_exlusive_timeout(mock_logger):
             timeout_seconds = 5
             start_time = time.time()
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_read_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
+                fd = acquire_flock_open_read_binary_(lock_file, mock_logger, timeout_seconds=timeout_seconds)
             duration_seconds = time.time() - start_time
             tolerance_seconds = 0.6
             assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
@@ -136,7 +136,7 @@ def test_flock_aquire_exlusive_timeout(mock_logger):
             timeout_seconds = 5
             start_time = time.time()
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
+                fd = acquire_flock_open_write_binary(lock_file, mock_logger, timeout_seconds=timeout_seconds)
             duration_seconds = time.time() - start_time
             tolerance_seconds = 0.6
             assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
@@ -150,11 +150,14 @@ def test_flock_shared_aquire(mock_logger):
     with tempfile.TemporaryDirectory() as tmp_dir_name:
         try:
             lock_file = f'{tmp_dir_name}/mylock.file'
+            # Lock file needs to be created
+            with open(lock_file,"w") as file:
+                file.write("Test file.")
             fd = None
             p = Process(target=get_and_hold_lock, args=(lock_file, 5, False))
             p.start()
             time.sleep(1)
-            fd = acquire_read_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
+            fd = acquire_flock_open_read_binary_(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is not None
             p.join()
         finally:

--- a/tests/test_utils_flock.py
+++ b/tests/test_utils_flock.py
@@ -1,0 +1,152 @@
+from multiprocessing import Process, Value
+import tempfile
+import time
+from unittest import mock
+
+import pytest
+from buildrunner.utils import ContainerLogger, acquire_flock, release_flock
+
+@pytest.fixture(name="mock_logger")
+def fixture_mock_logger():
+    mock_logger = mock.create_autospec(ContainerLogger)
+    mock_logger.write.side_effect = lambda message: print(message.strip())
+    return mock_logger
+
+def get_and_hold_lock(lock_file, sleep_seconds, exclusive=True, timeout_seconds=2):
+    fd = None
+    try:
+        mock_logger = mock.create_autospec(ContainerLogger)
+        mock_logger.write.side_effect = lambda message: print(message.strip())
+        fd = acquire_flock(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds, exclusive=exclusive)
+        assert fd is not None
+        time.sleep(sleep_seconds)
+    finally:
+        release_flock(fd, mock_logger)
+
+def test_flock_aquire(mock_logger):
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        try:
+            fd = None
+            lock_file = f'{tmp_dir_name}/mylock.file'
+            fd = acquire_flock(lock_file=lock_file, logger=mock_logger, timeout_seconds=1.0, exclusive=True,)
+            assert fd is not None
+
+        finally:
+            if fd:
+                release_flock(fd, mock_logger)
+
+def test_flock_exclusive_aquire(mock_logger):
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        try:
+            lock_file = f'{tmp_dir_name}/mylock.file'
+            fd = None
+
+            # Test exclusive followed by exclusive acquire
+            p = Process(target=get_and_hold_lock, args=(lock_file, 4))
+            p.start()
+            time.sleep(1)
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=1.0, exclusive=True,)
+            assert fd is None
+            p.join()
+
+            # Test shared followed by exclusive acquire
+            p = Process(target=get_and_hold_lock, args=(lock_file, 4, False))
+            p.start()
+            time.sleep(1)
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=1.0, exclusive=True,)
+            assert fd is None
+            p.join()
+
+            # Test exclusive followed by shared acquire
+            p = Process(target=get_and_hold_lock, args=(lock_file, 4, True))
+            p.start()
+            time.sleep(1)
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=1.0, exclusive=False,)
+            assert fd is None
+            p.join()
+
+        finally:
+            if fd:
+                release_flock(fd, mock_logger)
+
+def test_flock_release(mock_logger):
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        try:
+            lock_file = f'{tmp_dir_name}/mylock.file'
+            fd = None
+
+            p = Process(target=get_and_hold_lock, args=(lock_file, 2))
+            p.start()
+            time.sleep(1)
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=2.0, exclusive=True,)
+            assert fd is not None
+            p.join()
+        finally:
+            if fd:
+                release_flock(fd, mock_logger)
+
+def test_flock_aquire_exlusive_timeout(mock_logger):
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        try:
+            lock_file = f'{tmp_dir_name}/mylock.file'
+            fd = None
+
+            # Test exclusive followed by exclusive acquire
+            p = Process(target=get_and_hold_lock, args=(lock_file, 7))
+            p.start()
+            time.sleep(1)
+
+            timeout_seconds = 5
+            start_time = time.time()
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds, exclusive=True,)
+            duration_seconds = time.time() - start_time
+            tolerance_seconds = 0.6
+            assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
+            assert fd is None
+            p.join()
+
+            # Test exclusive followed by shared acquire
+            p = Process(target=get_and_hold_lock, args=(lock_file, 7))
+            p.start()
+            time.sleep(1)
+
+            timeout_seconds = 5
+            start_time = time.time()
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds, exclusive=False,)
+            duration_seconds = time.time() - start_time
+            tolerance_seconds = 0.6
+            assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
+            assert fd is None
+            p.join()
+
+            # Test shared followed by exclusive acquire
+            p = Process(target=get_and_hold_lock, args=(lock_file, 7, False))
+            p.start()
+            time.sleep(1)
+
+            timeout_seconds = 5
+            start_time = time.time()
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds, exclusive=True,)
+            duration_seconds = time.time() - start_time
+            tolerance_seconds = 0.6
+            assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
+            assert fd is None
+            p.join()
+        finally:
+            if fd:
+                release_flock(fd, mock_logger)
+
+def test_flock_shared_aquire(mock_logger):
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        try:
+            lock_file = f'{tmp_dir_name}/mylock.file'
+            fd = None
+            p = Process(target=get_and_hold_lock, args=(lock_file, 5, False))
+            p.start()
+            time.sleep(1)
+            fd = acquire_flock(lock_file, mock_logger, timeout_seconds=1.0, exclusive=False,)
+            assert fd is not None
+            p.join()
+        finally:
+            if fd:
+                release_flock(fd, mock_logger)

--- a/tests/test_utils_flock.py
+++ b/tests/test_utils_flock.py
@@ -5,7 +5,7 @@ from unittest import mock
 from os import path
 
 import pytest
-from buildrunner.utils import ContainerLogger, FailureToAcquireLockException, acquire_flock_open_read_binary_, acquire_flock_open_write_binary, release_flock
+from buildrunner.utils import ContainerLogger, FailureToAcquireLockException, acquire_flock_open_read_binary, acquire_flock_open_write_binary, release_flock
 
 @pytest.fixture(name="mock_logger")
 def fixture_mock_logger():
@@ -21,7 +21,7 @@ def get_and_hold_lock(lock_file, sleep_seconds, exclusive=True, timeout_seconds=
         if exclusive:
             fd = acquire_flock_open_write_binary(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds)
         else:
-            fd = acquire_flock_open_read_binary_(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds)
+            fd = acquire_flock_open_read_binary(lock_file=lock_file, logger=mock_logger, timeout_seconds=timeout_seconds)
         assert fd is not None
         time.sleep(sleep_seconds)
     finally:
@@ -68,7 +68,7 @@ def test_flock_exclusive_aquire(mock_logger):
             p.start()
             time.sleep(1)
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_flock_open_read_binary_(lock_file, mock_logger, timeout_seconds=1.0)
+                fd = acquire_flock_open_read_binary(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is None
             p.join()
 
@@ -121,7 +121,7 @@ def test_flock_aquire_exlusive_timeout(mock_logger):
             timeout_seconds = 5
             start_time = time.time()
             with pytest.raises(FailureToAcquireLockException):
-                fd = acquire_flock_open_read_binary_(lock_file, mock_logger, timeout_seconds=timeout_seconds)
+                fd = acquire_flock_open_read_binary(lock_file, mock_logger, timeout_seconds=timeout_seconds)
             duration_seconds = time.time() - start_time
             tolerance_seconds = 0.6
             assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
@@ -157,7 +157,7 @@ def test_flock_shared_aquire(mock_logger):
             p = Process(target=get_and_hold_lock, args=(lock_file, 5, False))
             p.start()
             time.sleep(1)
-            fd = acquire_flock_open_read_binary_(lock_file, mock_logger, timeout_seconds=1.0)
+            fd = acquire_flock_open_read_binary(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is not None
             p.join()
         finally:

--- a/tests/test_utils_flock.py
+++ b/tests/test_utils_flock.py
@@ -5,7 +5,7 @@ from unittest import mock
 from os import path
 
 import pytest
-from buildrunner.utils import ContainerLogger, acquire_read_binary_flock, acquire_write_binary_flock, release_flock
+from buildrunner.utils import ContainerLogger, FailureToAcquireLockException, acquire_read_binary_flock, acquire_write_binary_flock, release_flock
 
 @pytest.fixture(name="mock_logger")
 def fixture_mock_logger():
@@ -49,7 +49,8 @@ def test_flock_exclusive_aquire(mock_logger):
             p = Process(target=get_and_hold_lock, args=(lock_file, 4))
             p.start()
             time.sleep(1)
-            fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
+            with pytest.raises(FailureToAcquireLockException):
+                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is None
             p.join()
 
@@ -57,7 +58,8 @@ def test_flock_exclusive_aquire(mock_logger):
             p = Process(target=get_and_hold_lock, args=(lock_file, 4, False))
             p.start()
             time.sleep(1)
-            fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
+            with pytest.raises(FailureToAcquireLockException):
+                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is None
             p.join()
 
@@ -65,7 +67,8 @@ def test_flock_exclusive_aquire(mock_logger):
             p = Process(target=get_and_hold_lock, args=(lock_file, 4, True))
             p.start()
             time.sleep(1)
-            fd = acquire_read_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
+            with pytest.raises(FailureToAcquireLockException):
+                fd = acquire_read_binary_flock(lock_file, mock_logger, timeout_seconds=1.0)
             assert fd is None
             p.join()
 
@@ -102,7 +105,8 @@ def test_flock_aquire_exlusive_timeout(mock_logger):
 
             timeout_seconds = 5
             start_time = time.time()
-            fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
+            with pytest.raises(FailureToAcquireLockException):
+                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
             duration_seconds = time.time() - start_time
             tolerance_seconds = 0.6
             assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
@@ -116,7 +120,8 @@ def test_flock_aquire_exlusive_timeout(mock_logger):
 
             timeout_seconds = 5
             start_time = time.time()
-            fd = acquire_read_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
+            with pytest.raises(FailureToAcquireLockException):
+                fd = acquire_read_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
             duration_seconds = time.time() - start_time
             tolerance_seconds = 0.6
             assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)
@@ -130,7 +135,8 @@ def test_flock_aquire_exlusive_timeout(mock_logger):
 
             timeout_seconds = 5
             start_time = time.time()
-            fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
+            with pytest.raises(FailureToAcquireLockException):
+                fd = acquire_write_binary_flock(lock_file, mock_logger, timeout_seconds=timeout_seconds)
             duration_seconds = time.time() - start_time
             tolerance_seconds = 0.6
             assert (timeout_seconds - tolerance_seconds) <= duration_seconds <= (timeout_seconds + tolerance_seconds)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add timeout to file locking around saving and restoring caches. Add acquire and release lock functions in utils.py

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Some Jenkins jobs appear to be deadlocked around the existing file lock with caching. This is meant to lessen the pain of when deadlocks occur by allow other jobs to run. This doesn't address the root cause of the deadlocks however.

## How Has This Been Tested?

Unit tests were added around the new file lock timeout functions in utils

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.