### PR TITLE
Fix buildrunner file tests to use TemporaryDirectory for buildrunner results

### DIFF
--- a/tests/test-files/test-general.yaml
+++ b/tests/test-files/test-general.yaml
@@ -122,16 +122,6 @@ steps:
         'marathon.config': {'marathon.config': 'releng/testmodule'}
         'flight-director.config': {type: 'flight-director-config', 'fd:repo': 'releng/testmodule'}
 
-  containerize:
-    build:
-      path: tests
-      no-cache: true
-      inject:
-        'buildrunner.results/artifacts/*.txt': files/
-    push:
-      repository: adobe/buildrunner-test
-      tags: ['latest']
-
   test-dir-archive:
     run:
       image: {{ DOCKER_REGISTRY }}/rockylinux:8.5

--- a/tests/test-files/test-inject-nonexistent-dir.yaml
+++ b/tests/test-files/test-inject-nonexistent-dir.yaml
@@ -1,0 +1,10 @@
+steps:
+  containerize:
+    build:
+      path: tests
+      no-cache: true
+      inject:
+        'bogus_dir/*.txt': files/
+    push:
+      repository: adobe/buildrunner-test
+      tags: ['latest']

--- a/tests/test_buildrunner_files.py
+++ b/tests/test_buildrunner_files.py
@@ -31,6 +31,10 @@ def _get_test_args(file_name: str) -> Optional[List[str]]:
 def _get_exit_code(file_name: str) -> int:
     if file_name.startswith('test-xfail'):
         return os.EX_CONFIG
+
+    if file_name.startswith('test-inject-nonexistent-dir'):
+        return os.EX_CONFIG
+
     return os.EX_OK
 
 
@@ -48,8 +52,7 @@ def _test_buildrunner_file(test_dir, file_name, args, exit_code):
         command_line = [
             'buildrunner-test',
             '-d', top_dir_path,
-            # FIXME containerize step looks for buildrunner.results/artifacts/ and fails with temp_dir
-            # '-b', temp_dir,
+            '-b', temp_dir,
             # Since we are using a fresh temp directory, don't delete it first
             '--keep-step-artifacts',
             '-f', os.path.join(test_dir, file_name),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed buildrunner tests to use temporary directory for the buildrunner results directory. Moved a failing step in a buildrunner test file, which was attempting to inject a nonexistent directory.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.