### PR TITLE
Ensure that the source dir is marked safe for newer versions of git

### DIFF
--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -1011,6 +1011,10 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             )
 
             if _cmds:
+                # First ensure that the source directory is marked as safe for newer git versions
+                # Any errors are ignored here
+                self.runner.run("git config --global --add safe.directory /source")
+
                 # run each cmd
                 for _cmd in _cmds:
                     container_meta_logger.write(

--- a/tests/test-files/test-unsafe-git.yaml
+++ b/tests/test-files/test-unsafe-git.yaml
@@ -1,0 +1,14 @@
+steps:
+  test:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
+        RUN yum install -y git-core && yum clean all
+        WORKDIR /source
+        RUN useradd -m testuser
+        USER testuser
+    run:
+      cmds:
+      - git --version
+      # This fails if the git dir is "unsafe" and succeeds otherwise
+      - git log -n 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Newer versions of git can complain about an unsafe `/source` dir if the owner of the directory is different than the current owner. See https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765 for more info. This is not applicable to buildrunner invocations since they are run in docker images specified by the user. Therefore we always mark the git directory as safe before any commands are executed. This may not catch ALL cases where it is needed (i.e. entrypoint of the image triggers the issue), but it should cover a majority of cases. Any other cases will need to be handled by the user in their images by using the same (or similar) `git config` command.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
See the description above for context.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A functional test file was added that triggers the behavior. Without the fix, it fails, with the fix, it succeeds.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.