### PR TITLE
Add support for pushing python wheels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1071,8 +1071,8 @@ additional tags.
 Pushing To PyPI Repository
 ==========================
 The 'pypi-push' step attribute is used to push a python package to a remote PyPI
-repository. If an artifact with a type of ``python-sdist`` is present in the artifacts
-for the step, those packages will be pushed.
+repository. If an artifact with a type of ``python-sdist`` or ``python-wheel`` is present
+in the artifacts for the step, those packages will be pushed.
 
 The push only occurs if the --push argument is used, similar to how pushing docker
 images to remote docker registries works
@@ -1102,9 +1102,10 @@ doing this:
       run:
         image: python:2
         cmds:
-          - python setup.py sdist
+          - python -m build
         artifacts:
           "dist/*.tar.gz": { type: 'python-sdist' }
+          "dist/*.whl": { type: 'python-wheel' }
       pypi-push:
         repository: https://artifactory.example.com/artifactory/api/pypi/pypi-myownrepo
         username: myuser

--- a/buildrunner/steprunner/tasks/pypipush.py
+++ b/buildrunner/steprunner/tasks/pypipush.py
@@ -102,7 +102,7 @@ class PypiPushBuildStepRunnerTask(BuildStepRunnerTask):
                     _artifact.startswith(self.step_runner.name + "/")
                     and _attributes
                     and 'type' in _attributes
-                    and _attributes['type'] == "python-sdist"
+                    and _attributes['type'] in ("python-wheel", "python-sdist")
             ):
                 self.step_runner.build_runner.pypi_packages[self._repository]['packages'].append(
                     f"{self.step_runner.build_runner.build_results_dir}/{_artifact}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support pushing wheels as well as sdist packages for python.

## Related Issue

n/a

## Motivation and Context

Python builds using the `build` module build wheels as well as sdist packages by default. This helps support the use case more easily.

## How Has This Been Tested?

I conducted manual testing since pypi testing cannot be tested in automated testing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. - tested manually
- [x] All new and existing tests passed.