### PR TITLE
Add retries on multi-platform image builds

### DIFF
--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -13,6 +13,7 @@ from typing import List
 
 import python_on_whales
 from python_on_whales import docker
+from retry import retry
 
 from buildrunner.docker import get_dockerfile
 
@@ -212,6 +213,7 @@ class MultiplatformImageBuilder:
             LOGGER.warning("Local registry is not running when attempting to stop it")
 
     # pylint: disable=too-many-arguments
+    @retry(python_on_whales.exceptions.DockerException, tries=5, delay=1)
     def _build_single_image(self,
                             name: str,
                             platform: str,

--- a/requirements.in
+++ b/requirements.in
@@ -13,3 +13,4 @@ timeout-decorator>=0.5.0
 python-on-whales>=0.61.0
 # python-on-whales requires pydantic 1.10.11 08/2023
 pydantic>=1.10.11
+retry2>=0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ decorator==5.1.1
     # via
     #   -r requirements.in
     #   fabric
+    #   retry2
 docker==6.1.3
     # via -r requirements.in
 docutils==0.20.1
@@ -97,6 +98,8 @@ requests==2.31.0
     #   twine
 requests-toolbelt==1.0.0
     # via twine
+retry2==0.9.5
+    # via -r requirements.in
 rfc3986==2.0.0
     # via twine
 rich==13.4.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
An intermittent MP build failure occurs on build nodes. With a docker exception and error message similar to these:

> 16:07:27  #19 ERROR: Get "http://localhost:33321/v2/": read tcp [::1]:35204->[::1]:33321: read: connection reset by peer
> 16:07:27  ------
> 16:07:27   > pushing localhost:33321/buildrunner-mp-containerize-pr-125-265.i0fac61.m0-1-linux-arm64-v8:latest with docker:
> 16:07:27  ------
> 16:07:27  ERROR: Get "http://localhost:33321/v2/": read tcp [::1]:35204->[::1]:33321: read: connection reset by peer

This occurs on building MP images. And when retrying the build it does eventually successfully build. This is a quick fix until a deeper investigation can be completed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.