### PR TITLE
Change MP retry settings and add logging on failures

### DIFF
--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -213,7 +213,7 @@ class MultiplatformImageBuilder:
             logger.warning("Local registry is not running when attempting to stop it")
 
     # pylint: disable=too-many-arguments
-    @retry(python_on_whales.exceptions.DockerException, tries=5, delay=1)
+    @retry(python_on_whales.exceptions.DockerException, tries=3, delay=5, logger=logger)
     def _build_single_image(self,
                             name: str,
                             platform: str,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Provides more log information when the multi-platform image builds fails and also changed the settings a little bit. Hopefully these changes will improve the intermittent MP build failures we have seen. But if not, it should provide some additional log information that could be helpful.
 

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.