### PR TITLE
Fix blank global buildrunner config crash

### DIFF
--- a/buildrunner/config.py
+++ b/buildrunner/config.py
@@ -367,15 +367,17 @@ class BuildRunnerConfig:  # pylint: disable=too-many-instance-attributes
                     f"Redirect loop visiting previously visited file: {fetch_file}"
                 )
 
-        self._validate_version(config=config,
-                               version_file_path=f"{os.path.dirname(os.path.realpath(__file__))}/version.py")
+        if config:
+            self._validate_version(
+                config=config,
+                version_file_path=f"{os.path.dirname(os.path.realpath(__file__))}/version.py")
 
-        config = self._reorder_dependency_steps(config)
+            config = self._reorder_dependency_steps(config)
 
-        errors = validate_config(**config)
-        if errors:
-            raise BuildRunnerConfigurationError(f'Invalid configuration, {errors.count()} error(s) found:'
-                                                f'\n{errors}')
+            errors = validate_config(**config)
+            if errors:
+                raise BuildRunnerConfigurationError(f'Invalid configuration, {errors.count()} error(s) found:'
+                                                    f'\n{errors}')
 
         return config
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes crash issue when there is a blank global buildrunner config file. (i.e. ~/.buildrunner.yaml)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.