### PR TITLE
Use load instead of push to support remote builders

### DIFF
--- a/tests/test_multiplatform.py
+++ b/tests/test_multiplatform.py
@@ -14,6 +14,19 @@ TEST_DIR = os.path.basename(os.path.dirname(__file__))
 # FIXME: These tests can be broken if a custom buildx builder is set as default  # pylint: disable=fixme
 
 
+@pytest.fixture(autouse=True)
+def fixture_uuid_mock():
+    with patch('buildrunner.docker.multiplatform_image_builder.uuid') as uuid_mock:
+        counter = 0
+        def _get_uuid():
+            nonlocal counter
+            counter += 1
+            return f'uuid{counter}'
+
+        uuid_mock.uuid4.side_effect = _get_uuid
+        yield uuid_mock
+
+
 def actual_images_match_expected(actual_images, expected_images) -> List[str]:
     missing_images = []
     found = False
@@ -187,7 +200,7 @@ def test_find_native_platform(mock_os,
 @pytest.mark.parametrize("name, platforms, expected_image_names",[
     ('test-image-tag-2000',
      ['linux/arm64'],
-     ['test-image-tag-2000-linux-arm64']
+     ['buildrunner-mp-uuid1-linux-arm64']
     )])
 def test_tag_single_platform(name, platforms, expected_image_names):
     tag='latest'
@@ -221,7 +234,7 @@ def test_tag_single_platform(name, platforms, expected_image_names):
 @pytest.mark.parametrize("name, platforms, expected_image_names",[
     ('test-image-tag-2000',
      ['linux/arm64'],
-     ['test-image-tag-2000-linux-arm64']
+     ['buildrunner-mp-uuid1-linux-arm64']
     )])
 def test_tag_single_platform_multiple_tags(name, platforms, expected_image_names):
     tags=['latest', '0.1.0']
@@ -256,7 +269,7 @@ def test_tag_single_platform_multiple_tags(name, platforms, expected_image_names
 @pytest.mark.parametrize("name, platforms, expected_image_names",[
     ('test-image-tag-2000',
      ['linux/arm64'],
-     ['test-image-tag-2000-linux-arm64']
+     ['buildrunner-mp-uuid1-linux-arm64']
     )])
 def test_tag_single_platform_keep_images(name, platforms, expected_image_names):
     tag='latest'
@@ -377,11 +390,11 @@ def test_push_with_dest_names():
 @pytest.mark.parametrize("name, platforms, expected_image_names",[
     ('test-build-image-2000',
      ['linux/arm64'],
-     ['test-build-image-2000-linux-arm64']
+     ['buildrunner-mp-uuid1-linux-arm64']
     ),
     ('test-build-image-2001',
      ['linux/amd64', 'linux/arm64'],
-     ['test-build-image-2001-linux-amd64', 'test-build-image-2001-linux-arm64']
+     ['buildrunner-mp-uuid1-linux-amd64', 'buildrunner-mp-uuid1-linux-arm64']
     )
 ])
 @patch('buildrunner.docker.multiplatform_image_builder.docker.image.remove')
@@ -415,11 +428,11 @@ def test_build_multiple_builds(mock_build, mock_pull, mock_inspect, mock_remove)
     mock_inspect.return_value.id = 'myfakeimageid'
     name1 = 'test-build-multi-image-2001'
     platforms1 = ['linux/amd64', 'linux/arm64']
-    expected_image_names1 = ['test-build-multi-image-2001-linux-amd64', 'test-build-multi-image-2001-linux-arm64']
+    expected_image_names1 = ['buildrunner-mp-uuid1-linux-amd64', 'buildrunner-mp-uuid1-linux-arm64']
 
     name2 = 'test-build-multi-image-2002'
     platforms2 = ['linux/amd64', 'linux/arm64']
-    expected_image_names2 = ['test-build-multi-image-2002-linux-amd64', 'test-build-multi-image-2002-linux-arm64']
+    expected_image_names2 = ['buildrunner-mp-uuid2-linux-amd64', 'buildrunner-mp-uuid2-linux-arm64']
 
     test_path = f'{TEST_DIR}/test-files/multiplatform'
     with MultiplatformImageBuilder() as mp:
@@ -454,12 +467,12 @@ def test_build_multiple_builds(mock_build, mock_pull, mock_inspect, mock_remove)
     ('test-build-tag-image-2000',
      ['latest', '0.1.0'],
      ['linux/arm64'],
-     ['test-build-tag-image-2000-linux-arm64']
+     ['buildrunner-mp-uuid1-linux-arm64']
     ),
     ('test-build-tag-image-2001',
      ['latest', '0.2.0'],
      ['linux/amd64', 'linux/arm64'],
-     ['test-build-tag-image-2001-linux-amd64', 'test-build-tag-image-2001-linux-arm64']
+     ['buildrunner-mp-uuid1-linux-amd64', 'buildrunner-mp-uuid1-linux-arm64']
     )
 ])
 def test_build_with_tags(name, tags, platforms, expected_image_names):

--- a/tests/test_multiplatform.py
+++ b/tests/test_multiplatform.py
@@ -399,9 +399,10 @@ def test_push_with_dest_names():
 ])
 @patch('buildrunner.docker.multiplatform_image_builder.docker.image.remove')
 @patch('buildrunner.docker.multiplatform_image_builder.docker.image.inspect')
+@patch('buildrunner.docker.multiplatform_image_builder.docker.push')
 @patch('buildrunner.docker.multiplatform_image_builder.docker.image.pull')
 @patch('buildrunner.docker.multiplatform_image_builder.docker.buildx.build')
-def test_build(mock_build, mock_pull, mock_inspect, mock_remove, name, platforms, expected_image_names):
+def test_build(mock_build, mock_pull, mock_push, mock_inspect, mock_remove, name, platforms, expected_image_names):
     mock_inspect.return_value = MagicMock()
     mock_inspect.return_value.id = 'myfakeimageid'
     test_path = f'{TEST_DIR}/test-files/multiplatform'
@@ -421,9 +422,10 @@ def test_build(mock_build, mock_pull, mock_inspect, mock_remove, name, platforms
 
 @patch('buildrunner.docker.multiplatform_image_builder.docker.image.remove')
 @patch('buildrunner.docker.multiplatform_image_builder.docker.image.inspect')
+@patch('buildrunner.docker.multiplatform_image_builder.docker.push')
 @patch('buildrunner.docker.multiplatform_image_builder.docker.image.pull')
 @patch('buildrunner.docker.multiplatform_image_builder.docker.buildx.build')
-def test_build_multiple_builds(mock_build, mock_pull, mock_inspect, mock_remove):
+def test_build_multiple_builds(mock_build, mock_pull, mock_push, mock_inspect, mock_remove):
     mock_inspect.return_value = MagicMock()
     mock_inspect.return_value.id = 'myfakeimageid'
     name1 = 'test-build-multi-image-2001'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds support for building on remote builders that cannot access the local registry.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When using remote builders, they cannot access the temporary local registry since it runs on localhost. Attempting to do with fully qualified names is also problematic unless we set up full certs, auth, etc. To prevent this, we can simply --load instead of --push'ing in the buildx build, then push the resulting image for the final manifest creation.

## How Has This Been Tested?

I tested this in a development environment to ensure it does as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.