### PR TITLE
Prevent no resource to delete error

### DIFF
--- a/buildrunner/steprunner/tasks/build.py
+++ b/buildrunner/steprunner/tasks/build.py
@@ -245,10 +245,10 @@ class BuildBuildStepRunnerTask(MultiPlatformBuildStepRunnerTask):  # pylint: dis
                 )
                 if exit_code != 0 or not builder.image:
                     raise BuildRunnerProcessingError('Error building image')
+                context['image'] = builder.image
+                self.step_runner.build_runner.generated_images.append(builder.image)
         except Exception as exc:
             self.step_runner.log.write(f'ERROR: {exc}\n')
             raise
         finally:
             builder.cleanup()
-        context['image'] = builder.image
-        self.step_runner.build_runner.generated_images.append(builder.image)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current release of buildrunner shows an error when building multiplatform images. This error is ignored and everything works fine, it just makes people think that something actually went wrong. This fixes that.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The error is related to trying to cleanup images that were built. Since multiplatform images are built differently than single platform images and cleaned up differently as well, we just need to not do the code that handles cleaning up images when building multiplatform.

## How Has This Been Tested?

I tested this manually on a build agent.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.