### PR TITLE
Add more output logging for multiplatform builds

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -583,6 +583,7 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
         exit_explanation = None
         try:  # pylint: disable=too-many-nested-blocks
             with MultiplatformImageBuilder(
+                log=self.log,
                 docker_registry=self.global_config.get_docker_registry(),
                 keep_images=not self.cleanup_images,
                 temp_dir=self.global_config.get_temp_dir(),

--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -10,6 +10,7 @@ import os
 from multiprocessing import Manager, Process
 from platform import machine, system
 import shutil
+import sys
 import tempfile
 import uuid
 from typing import Dict, List, Optional
@@ -121,6 +122,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
     def __init__(
             self,
+            log=sys.stdout,
             docker_registry: Optional[str] = None,
             use_local_registry: bool = True,
             keep_images: bool = False,
@@ -128,6 +130,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
             disable_multi_platform: bool = False,
             platform_builders: Optional[Dict[str, str]] = None,
     ):
+        self._log = log
         self._docker_registry = docker_registry
         self._mp_registry_info = None
         self._use_local_registry = use_local_registry
@@ -315,7 +318,8 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
 
         tagged_names = [f"{name}:{tag}" for tag in tags]
         builder = self._platform_builders.get(platform) if self._platform_builders else None
-        logger.debug(f"Building {tagged_names} for {platform} with {builder or 'default'} builder")
+        logger.debug(f"Building tagged images {tagged_names}")
+        self._log.write(f"Building image for platform {platform} with {builder or 'default'} builder\n")
 
         if inject and isinstance(inject, dict):
             self._build_with_inject(
@@ -451,20 +455,27 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
 
         if self._disable_multi_platform:
             platforms = [self.get_single_platform_to_build(platforms)]
-            print(f"{line}\n"
-                  f"Note: Disabling multi-platform build, "
-                  "this will only build a single-platform image.\n"
-                  f"image: {sanitized_name} platform:{platforms[0]}\n"
-                  f"{line}")
+            self._log.write(
+                f"{line}\n"
+                f"Note: Disabling multi-platform build, "
+                "this will only build a single-platform image.\n"
+                f"image: {sanitized_name} platform:{platforms[0]}\n"
+                f"{line}\n"
+            )
         else:
-            print(f"{line}\n"
-                  f"Note: Building multi-platform images can take a long time, please be patient.\n"
-                  "If you are running this locally, you can speed this up by using the "
-                  "'--disable-multi-platform' CLI flag "
-                  "or set the 'disable-multi-platform' flag in the global config file.\n"
-                  f"{line}")
+            self._log.write(
+                f"{line}\n"
+                f"Note: Building multi-platform images can take a long time, please be patient.\n"
+                "If you are running this locally, you can speed this up by using the "
+                "'--disable-multi-platform' CLI flag "
+                "or set the 'disable-multi-platform' flag in the global config file.\n"
+                f"{line}\n"
+            )
 
         processes = []
+        self._log.write(
+            f'Starting builds for {len(platforms)} platforms in {"parallel" if do_multiprocessing else "sequence"}\n'
+        )
         for platform in platforms:
             platform_image_name = f"{base_image_name}-{platform.replace('/', '-')}"
             build_single_image_args = (

--- a/tests/test_multiplatform.py
+++ b/tests/test_multiplatform.py
@@ -75,7 +75,7 @@ def test_start_local_registry_on_build():
     registry_name = None
     volume_name = None
 
-    with MultiplatformImageBuilder() as mp:
+    with MultiplatformImageBuilder(log=MagicMock()) as mp:
         # Check that the registry is NOT running
         assert mp._mp_registry_info is None
         assert mp._local_registry_is_running is False
@@ -113,7 +113,7 @@ def test_start_local_registry_on_build():
                                  platforms=['linux/arm64', 'linux/amd64'],
                                  path=test_path,
                                  file=f'{test_path}/Dockerfile',
-                                 do_multiprocessing=True)
+                                 do_multiprocessing=False)
 
         registry_name = mp._mp_registry_info.name
         assert first_registry_name == registry_name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add more output logging for multiplatform builds. Example output:

```
==> Running step: push-container:build
Pull was not specified in configuration, defaulting to True
Running docker build
-----------------------------------------------------------------
Note: Building multi-platform images can take a long time, please be patient.
If you are running this locally, you can speed this up by using the '--disable-multi-platform' CLI flag or set the 'disable-multi-platform' flag in the global config file.
-----------------------------------------------------------------
Starting builds for 2 platforms in parallel
Building image for platform linux/arm64 with arm1 builder
Building image for platform linux/amd64 with default builder
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I had a hard time telling if ARM builds were running on the correct builder or not from normal build logs. The debug output would give that to me, but not the normal output.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.