### PR TITLE
Move back to print for logging to console in multiplatform builder

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -583,7 +583,6 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
         exit_explanation = None
         try:  # pylint: disable=too-many-nested-blocks
             with MultiplatformImageBuilder(
-                log=self.log,
                 docker_registry=self.global_config.get_docker_registry(),
                 keep_images=not self.cleanup_images,
                 temp_dir=self.global_config.get_temp_dir(),

--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -10,7 +10,6 @@ import os
 from multiprocessing import Manager, Process
 from platform import machine, system
 import shutil
-import sys
 import tempfile
 import uuid
 from typing import Dict, List, Optional
@@ -122,7 +121,6 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-arguments
     def __init__(
             self,
-            log=sys.stdout,
             docker_registry: Optional[str] = None,
             use_local_registry: bool = True,
             keep_images: bool = False,
@@ -130,7 +128,6 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
             disable_multi_platform: bool = False,
             platform_builders: Optional[Dict[str, str]] = None,
     ):
-        self._log = log
         self._docker_registry = docker_registry
         self._mp_registry_info = None
         self._use_local_registry = use_local_registry
@@ -319,7 +316,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
         tagged_names = [f"{name}:{tag}" for tag in tags]
         builder = self._platform_builders.get(platform) if self._platform_builders else None
         logger.debug(f"Building tagged images {tagged_names}")
-        self._log.write(f"Building image for platform {platform} with {builder or 'default'} builder\n")
+        print(f"Building image for platform {platform} with {builder or 'default'} builder")
 
         if inject and isinstance(inject, dict):
             self._build_with_inject(
@@ -455,26 +452,26 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
 
         if self._disable_multi_platform:
             platforms = [self.get_single_platform_to_build(platforms)]
-            self._log.write(
+            print(
                 f"{line}\n"
                 f"Note: Disabling multi-platform build, "
                 "this will only build a single-platform image.\n"
                 f"image: {sanitized_name} platform:{platforms[0]}\n"
-                f"{line}\n"
+                f"{line}"
             )
         else:
-            self._log.write(
+            print(
                 f"{line}\n"
                 f"Note: Building multi-platform images can take a long time, please be patient.\n"
                 "If you are running this locally, you can speed this up by using the "
                 "'--disable-multi-platform' CLI flag "
                 "or set the 'disable-multi-platform' flag in the global config file.\n"
-                f"{line}\n"
+                f"{line}"
             )
 
         processes = []
-        self._log.write(
-            f'Starting builds for {len(platforms)} platforms in {"parallel" if do_multiprocessing else "sequence"}\n'
+        print(
+            f'Starting builds for {len(platforms)} platforms in {"parallel" if do_multiprocessing else "sequence"}'
         )
         for platform in platforms:
             platform_image_name = f"{base_image_name}-{platform.replace('/', '-')}"

--- a/tests/test_multiplatform.py
+++ b/tests/test_multiplatform.py
@@ -75,7 +75,7 @@ def test_start_local_registry_on_build():
     registry_name = None
     volume_name = None
 
-    with MultiplatformImageBuilder(log=MagicMock()) as mp:
+    with MultiplatformImageBuilder() as mp:
         # Check that the registry is NOT running
         assert mp._mp_registry_info is None
         assert mp._local_registry_is_running is False


### PR DESCRIPTION
The log writer cannot be pickled to be used in multiprocess builds, and therefore is broken most of the time. Using print prevents that. This fixes a bug introduced with the last release.