### PR TITLE
Fix problems with injecting a dir in multiplatform build

### DIFF
--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -265,7 +265,10 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
                 if not os.path.isdir(dest_dir):
                     os.mkdir(dest_dir)
 
-                shutil.copy(src_path, dest_path)
+                if os.path.isdir(src_path):
+                    shutil.copytree(src_path, dest_path)
+                else:
+                    shutil.copy(src_path, dest_path)
 
             assert os.path.isdir(context_dir), f"Failed to create context dir {context_dir}"
 

--- a/tests/test-files/test-multi-platform-inject.yaml
+++ b/tests/test-files/test-multi-platform-inject.yaml
@@ -72,3 +72,27 @@ steps:
       inject:
         tests/test-files/inject/file1.txt: files/file.txt
       no-cache: true
+  build-mp-dir-inject:
+    build:
+      path: .
+      dockerfile: |
+        FROM bash:5.2.15
+        ADD inject/file1.txt /file.txt
+      platforms:
+        - linux/amd64
+        - linux/arm64
+      inject:
+        tests/test-files/inject: inject
+      no-cache: true
+  build-mp-dir-top-inject:
+    build:
+      path: .
+      dockerfile: |
+        FROM bash:5.2.15
+        ADD inject/file1.txt /file.txt
+      platforms:
+        - linux/amd64
+        - linux/arm64
+      inject:
+        tests/test-files/inject: .
+      no-cache: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Injecting a dir results in a failure since shutil.copy cannot handle dirs.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This fixes the bug to correctly inject dirs.

## How Has This Been Tested?

I added a unit test to verify correct behavior.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.