### PR TITLE
Add env var for platform of underlying device

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -485,6 +485,7 @@ Buildrunner injects special environment variables and volume mounts into every
 run container. The following environment variables are set and available in
 every run container:
 
+:``BUILDRUNNER_PLATFORM``: the platform of the current device (x86_64, aarch64, etc), equivalent to ``platform.machine()``
 :``BUILDRUNNER_BUILD_NUMBER``: the build number
 :``BUILDRUNNER_BUILD_ID``: a unique id identifying the build (includes vcs and build number
                            information), e.g. "main-1791.Ia09cc5.M0-1661374484"

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -16,6 +16,7 @@ import inspect
 import json
 import logging
 import os
+import platform as python_platform
 import shutil
 import sys
 import tarfile
@@ -89,6 +90,7 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
         """
 
         context = {
+            'BUILDRUNNER_PLATFORM': str(python_platform.machine()),
             'BUILDRUNNER_BUILD_NUMBER': str(self.build_number),
             'BUILDRUNNER_BUILD_ID': str(self.build_id),
             'BUILDRUNNER_BUILD_DOCKER_TAG': str(sanitize_tag(self.build_id)),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = '3.0'
+BASE_VERSION = '3.1'
 
 SOURCE_DIR = os.path.dirname(
     os.path.abspath(__file__)

--- a/tests/test-files/test-general.yaml
+++ b/tests/test-files/test-general.yaml
@@ -146,3 +146,9 @@ steps:
     run:
       image: {{ DOCKER_REGISTRY }}/centos:8
       cmd: 'if [ $(ls -laR /artifacts/setup-uncompress-dirs/ | grep tar.gz | wc -l) != 0 ]; then exit 1; fi'
+
+  test-platform:
+    run:
+      image: {{ DOCKER_REGISTRY }}/centos:8
+      cmd: 'if [ -z "{{ BUILDRUNNER_PLATFORM }}" ]; then exit 1; else echo "Platform is {{ BUILDRUNNER_PLATFORM }}"; fi'
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an environment variable for buildrunner.yaml files to be able to tell the underlying architecture of the system that buildrunner is running on (i.e. ARM, AMD, etc).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There is no way, currently, to tell the underlying architecture of the current machine that buildrunner is running on (i.e. ARM vs AMD). This adds an env var to be able to tell that, which can then be used in the buildrunner.yaml file to mark built artifacts as being for one platform vs another.

## How Has This Been Tested?

I added a test step in the test files to ensure that the platform is being set to something and it errors if it is not set (tested locally without this change and with this change and it works properly).

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.