### PR TITLE
Use default cache dir if there are errors with configured cache dir

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -438,7 +438,7 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
             local_cache_archive_file = get_filename(caches_root, cache_name)
         except Exception as exc:  # pylint: disable=broad-except
             # Intentinally catch all exceptions here since we don't want to fail the build
-            LOGGER.warning(f'There was a an issue with {caches_root}: {str(exc)}')
+            LOGGER.warning(f'There was an issue with {caches_root}: {str(exc)}')
             local_cache_archive_file = get_filename(DEFAULT_CACHES_ROOT, cache_name)
             LOGGER.warning(f'Using {DEFAULT_CACHES_ROOT} for the cache directory')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Use the default cache directory if there are any errors with the cache root dir in the global config. Rather than failing the build, this will print warnings of the failures with the directory and proceed with the building using the default cache directory on the local file system.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.