### PR TITLE
Add cache_from and cache_to support for multiplatform builds

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -69,7 +69,9 @@ disable=logging-fstring-interpolation,
         unnecessary-pass,
         wrong-import-order,
         too-few-public-methods,
-        cyclic-import
+        cyclic-import,
+        missing-class-docstring,
+        missing-function-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/README.rst
+++ b/README.rst
@@ -171,8 +171,8 @@ they are used when put into the global configuration file:
     some.other.file.alias: |
       The contents of the file...
 
-  # The 'caches-root' global configuration specifies the directory to use for
-  # build caches. The default directory is ~/.buildrunner/caches.
+  # Specifies the directory to use for the build caches, the default directory
+  # is ~/.buildrunner/caches
   caches-root: ~/.buildrunner/caches
 
   # Change the default docker registry, see the FAQ below for more information
@@ -195,6 +195,22 @@ they are used when put into the global configuration file:
   # here will use the default configured buildx builder.
   platform-builders:
     platform1: builder1
+
+  # Configures caching *for multi-platform builds only*
+  docker-build-cache:
+    # An optional list of builders to apply caching options to
+    # NOTE: These caching options do not work for the default (docker) buildx driver,
+    #       so be careful which builders they are configured for as this could cause
+    #       build failures
+    builders:
+    - builder1
+    # See https://docs.docker.com/build/cache/backends/ for information on how to
+    # configure the caching backend. These may be strings or dictionaries (both are
+    # shown below).
+    to: type=local,dest=/mnt/docker-cache
+    from:
+      type: local
+      src: /mnt/docker-cache
 
 Configuration Locations
 -----------------------
@@ -422,6 +438,7 @@ shows the different configuration options available:
         # Buildrunner will attempt to pull these images from the remote registry.
         # If the pull is unsuccessful, buildrunner will still pass in the image name
         # into --cache-from, allowing a cache check in the host machine cache
+        # NOTE: Does not work for multi-platform builds
         cache_from:
           - my-images/image:PR-123
           - my-images/image:latest

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -590,6 +590,9 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
                 temp_dir=self.global_config.get_temp_dir(),
                 disable_multi_platform=self.disable_multi_platform,
                 platform_builders=self.global_config.get('platform-builders'),
+                cache_builders=self.global_config.get_docker_build_cache_config().get('builders'),
+                cache_from=self.global_config.get_docker_build_cache_config().get('from'),
+                cache_to=self.global_config.get_docker_build_cache_config().get('to'),
             ) as multi_platform:
                 if not os.path.exists(self.build_results_dir):
                     # create a new results dir

--- a/buildrunner/config.py
+++ b/buildrunner/config.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import tempfile
+from typing import Optional
 
 import jinja2
 
@@ -395,6 +396,9 @@ class BuildRunnerConfig:  # pylint: disable=too-many-instance-attributes
         Default to docker.io if none is configured
         """
         return self.global_config.get('docker-registry', 'docker.io')
+
+    def get_docker_build_cache_config(self) -> Optional[dict]:
+        return self.global_config.get('docker-build-cache', {})
 
     def to_abs_path(self, path, return_list=False):
         """

--- a/buildrunner/steprunner/tasks/build.py
+++ b/buildrunner/steprunner/tasks/build.py
@@ -224,7 +224,6 @@ class BuildBuildStepRunnerTask(MultiPlatformBuildStepRunnerTask):  # pylint: dis
                     build_args=self.buildargs,
                     inject=self.to_inject,
                     cache=not self.nocache,
-                    cache_from=self.cache_from,
                     pull=self.pull,
                 )
 

--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -34,6 +34,11 @@ class Config(BaseModel, extra='forbid'):
         prompt_password: Optional[bool] = Field(alias='prompt-password', default=None)
         aliases: Optional[List[str]] = None
 
+    class DockerBuildCacheConfig(BaseModel, extra='forbid'):
+        builders: Optional[List[str]] = None
+        from_config: Optional[Union[dict, str]] = Field(None, alias='from')
+        to_config: Optional[Union[dict, str]] = Field(None, alias='to')
+
     version: Optional[float] = None
     steps: Optional[Dict[str, Step]] = None
 
@@ -44,6 +49,7 @@ class Config(BaseModel, extra='forbid'):
     #  Intentionally has loose restrictions on ssh-keys since documentation isn't clear
     ssh_keys: Optional[Union[SSHKey, List[SSHKey]]] = Field(alias='ssh-keys', default=None)
     local_files: Optional[Dict[str, str]] = Field(alias='local-files', default=None)
+    docker_build_cache: Optional[DockerBuildCacheConfig] = Field(None, alias='docker-build-cache')
     caches_root: Optional[str] = Field(alias='caches-root', default=None)
     docker_registry: Optional[str] = Field(alias='docker-registry', default=None)
     temp_dir: Optional[str] = Field(alias='temp-dir', default=None)
@@ -123,6 +129,9 @@ class Config(BaseModel, extra='forbid'):
 
                     if not isinstance(step.build.platforms, list):
                         raise ValueError(f'platforms must be a list in build step {step_name}')
+
+                    if step.build.cache_from:
+                        raise ValueError(f'cache_from is not allowed in multi-platform build step {step_name}')
 
                     if step.build.import_param:
                         raise ValueError(f'import is not allowed in multi-platform build step {step_name}')

--- a/tests/test_buildrunner_files.py
+++ b/tests/test_buildrunner_files.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple
 from tests import test_runner
 
 test_dir_path = os.path.realpath(os.path.dirname(__file__))
-TEST_DIR = os.path.basename(os.path.dirname(__file__))
+TEST_DIR = os.path.dirname(__file__)
 top_dir_path = os.path.realpath(os.path.dirname(test_dir_path))
 
 

--- a/tests/test_config_validation/test_validation_step.py
+++ b/tests/test_config_validation/test_validation_step.py
@@ -48,6 +48,31 @@ def test_platforms_invalid():
     assert errors.count() == 2
 
 
+def test_cache_from_invalid():
+    # Invalid to have cache_from specified with platforms
+    config_yaml = """
+    steps:
+      build-container-multi-platform:
+        build:
+          path: .
+          dockerfile: Dockerfile
+          pull: false
+          platforms:
+          - linux/amd64
+          cache_from:
+          - image1
+        push:
+          repository: mytest-reg/buildrunner-test-multi-platform
+          tags:
+            - latest
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+    assert 'cache_from' in str(errors)
+
+
 def test_build_is_path():
     config_yaml = """
     steps:
@@ -92,8 +117,6 @@ def test_valid_platforms():
             - linux/amd64
             - linux/arm64
           no-cache: true
-          cache_from:
-            - mytest-reg/buildrunner-test-multi-platform:latest
         push:
           repository: mytest-reg/buildrunner-test-multi-platform
           tags:

--- a/tests/test_multiplatform.py
+++ b/tests/test_multiplatform.py
@@ -477,6 +477,7 @@ def test_build_multiple_builds(mock_build, mock_pull, mock_push, mock_inspect, m
             builder=None,
             cache=False,
             cache_from=None,
+            cache_to=None,
             pull=False
         ),
         call(
@@ -489,6 +490,7 @@ def test_build_multiple_builds(mock_build, mock_pull, mock_push, mock_inspect, m
             builder=None,
             cache=False,
             cache_from=None,
+            cache_to=None,
             pull=False
         ),
         call(
@@ -501,6 +503,7 @@ def test_build_multiple_builds(mock_build, mock_pull, mock_push, mock_inspect, m
             builder=None,
             cache=False,
             cache_from=None,
+            cache_to=None,
             pull=False
         ),
         call(
@@ -513,6 +516,7 @@ def test_build_multiple_builds(mock_build, mock_pull, mock_push, mock_inspect, m
             builder=None,
             cache=False,
             cache_from=None,
+            cache_to=None,
             pull=False
         ),
     ]
@@ -567,3 +571,18 @@ def test_no_images_built():
     with MultiplatformImageBuilder() as mp:
         image = mp._find_native_platform_images('bogus-image-name')
         assert image is None
+
+
+@pytest.mark.parametrize('builder, cache_builders, return_cache_options', [
+    ('b1', None, True),
+    ('b1', [], True),
+    ('b1', ['b1'], True),
+    ('b2', ['b1'], False),
+])
+def test__get_build_cache_options(builder, cache_builders, return_cache_options):
+    multi_platform = MultiplatformImageBuilder(
+        cache_to='to-loc', cache_from='from-loc', cache_builders=cache_builders,
+    )
+    assert multi_platform._get_build_cache_options(builder) == (
+        {'cache_to': 'to-loc', 'cache_from': 'from-loc'} if return_cache_options else {}
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for cache_from/cache_to parameters for docker buildx (multiplatform) builds.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

We would like to add more caching for docker, and this is one available option for us. This does not solve all problems as it only works for buildx builds (which are used in multiplatform builds) and also only specific buildx builder drivers (container and remote is what has been tested so far), but it is a start.

## How Has This Been Tested?

I have run this against multiple builders in different configurations and confirmed that the build cache directory is created locally (even when using a remote builder).

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.