### PR TITLE
Add support for arbitrary build registries in multiplatform builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,11 @@ they are used when put into the global configuration file:
   # the configuration in the buildrunner.yaml file.
   disable-multi-platform: true/false (defaults to false)
 
+  # Optionally uses a registry for temporary multi-platform builds
+  # If not specified or set to "local", uses a temporary registry Docker container
+  # which only lives for the duration of the build
+  build-registry: docker-build.example.com
+
   # Overrides the buildx builder used when doing multi-platform builds. Buildx
   # does not provide the capability to auto-select the builder based on the platform
   # and therefore this must be configured in buildrunner itself to perform builds

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -606,6 +606,7 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
         try:  # pylint: disable=too-many-nested-blocks
             with MultiplatformImageBuilder(
                 docker_registry=self.global_config.get_docker_registry(),
+                build_registry=self.global_config.get_build_registry(),
                 temp_dir=self.global_config.get_temp_dir(),
                 disable_multi_platform=self.disable_multi_platform,
                 platform_builders=self.global_config.get("platform-builders"),

--- a/buildrunner/config.py
+++ b/buildrunner/config.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 import jinja2
 
+from buildrunner.docker import multiplatform_image_builder
 from buildrunner.errors import (
     BuildRunnerConfigurationError,
     BuildRunnerVersionError,
@@ -423,6 +424,14 @@ class BuildRunnerConfig:  # pylint: disable=too-many-instance-attributes
         Default to docker.io if none is configured
         """
         return self.global_config.get("docker-registry", "docker.io")
+
+    def get_build_registry(self):
+        """
+        Default to local registry if none is configured
+        """
+        return self.global_config.get(
+            "build-registry", multiplatform_image_builder.LOCAL_REGISTRY
+        )
 
     def get_docker_build_cache_config(self) -> Optional[dict]:
         return self.global_config.get("docker-build-cache", {})

--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -8,6 +8,7 @@ with the terms of the Adobe license agreement accompanying it.
 import logging
 import os
 import platform as python_platform
+import re
 import shutil
 import tempfile
 import uuid
@@ -26,6 +27,9 @@ from buildrunner.docker.image_info import BuiltImageInfo, BuiltTaggedImage
 
 LOGGER = logging.getLogger(__name__)
 OUTPUT_LINE = "-----------------------------------------------------------------"
+# Marker for using the local registry instead of an upstream registry
+LOCAL_REGISTRY = "local"
+IMAGE_PREFIX = "buildrunner-mp"
 
 PUSH_TIMEOUT = 300
 
@@ -69,7 +73,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         docker_registry: Optional[str] = None,
-        use_local_registry: bool = True,
+        build_registry: Optional[str] = None,
         temp_dir: str = os.getcwd(),
         disable_multi_platform: bool = False,
         platform_builders: Optional[Dict[str, str]] = None,
@@ -78,8 +82,8 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
         cache_to: Optional[Union[dict, str]] = None,
     ):
         self._docker_registry = docker_registry
-        self._mp_registry_info = None
-        self._use_local_registry = use_local_registry
+        self._build_registry = build_registry
+        self._use_local_registry = build_registry == LOCAL_REGISTRY
         self._temp_dir = temp_dir
         self._disable_multi_platform = disable_multi_platform
         self._platform_builders = platform_builders
@@ -94,6 +98,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
 
         self._built_images: List[BuiltImageInfo] = []
         self._local_registry_is_running = False
+        self._mp_registry_info = None
 
     def __enter__(self):
         return self
@@ -107,9 +112,11 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
         """Returns true if multi-platform builds are disabled by configuration, false otherwise"""
         return self._disable_multi_platform
 
-    def registry_address(self) -> str:
+    def _build_registry_address(self) -> str:
         """Returns the address of the local registry"""
-        return f"{self._mp_registry_info.ip_addr}:{self._mp_registry_info.port}"
+        if self._build_registry == LOCAL_REGISTRY:
+            return f"{self._mp_registry_info.ip_addr}:{self._mp_registry_info.port}"
+        return self._build_registry
 
     def _start_local_registry(self):
         """
@@ -388,8 +395,12 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
             # Starts local registry container to do ephemeral image storage
             self._start_local_registry()
 
-        # The name should stay consistent and the tags are variable per build step/platform
-        repo = f"{self._mp_registry_info.ip_addr}:{self._mp_registry_info.port}/buildrunner-mp"
+        # Uses the current node name as the repo
+        if python_platform.node():
+            sanitized_name = f"{IMAGE_PREFIX}-{re.sub(r'[^a-zA-Z0-9]', '', python_platform.node()).lower()}"
+        else:
+            sanitized_name = f"{IMAGE_PREFIX}-unknown-node"
+        repo = f"{self._build_registry_address()}/{sanitized_name}"
 
         if self._disable_multi_platform:
             platforms = [self._get_single_platform_to_build(platforms)]

--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -73,7 +73,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         docker_registry: Optional[str] = None,
-        build_registry: Optional[str] = None,
+        build_registry: Optional[str] = LOCAL_REGISTRY,
         temp_dir: str = os.getcwd(),
         disable_multi_platform: bool = False,
         platform_builders: Optional[Dict[str, str]] = None,

--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Set, Union
 # pylint: disable=no-name-in-module
 from pydantic import BaseModel, Field, field_validator, ValidationError
 
+from buildrunner.docker import multiplatform_image_builder
 from buildrunner.validation.errors import Errors, get_validation_errors
 from buildrunner.validation.step import Step, StepPushCommitDict
 
@@ -63,6 +64,9 @@ class Config(BaseModel, extra="forbid"):
     temp_dir: Optional[str] = Field(alias="temp-dir", default=None)
     disable_multi_platform: Optional[bool] = Field(
         alias="disable-multi-platform", default=None
+    )
+    build_registry: Optional[str] = Field(
+        alias="build-registry", default=multiplatform_image_builder.LOCAL_REGISTRY
     )
     platform_builders: Optional[Dict[str, str]] = Field(
         alias="platform-builders", default=None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Using a local build registry for multiplatform builds can be quite slow as it pushes large images to the local registry. This allows users to use an arbitrary registry and benefit from caches, etc. This also allows multiplatform builds to occur on disparate systems without too much trouble.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

See above

## How Has This Been Tested?

I tested this minimally locally. It definitely needs further testing and unit tests written to cover it.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.