### PR TITLE
Implement multi-platform re-tag config validation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -561,6 +561,7 @@ the run step:
         - test-step
         - validation-step
 
+      # This is not supported in the same step as a multi-platform build.
       run:
         # xfail indicates whether the run operation is expected to fail.  The
         # default is false - the operation is expected to succeed.  If xfail

--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -18,6 +18,7 @@ from buildrunner.validation.step import Step, StepPushCommitDict
 from buildrunner.validation.step_images_info import StepImagesInfo
 
 RETAG_ERROR_MESSAGE = "Multi-platform build steps cannot re-tag images. The following images are re-tagged:"
+RUN_MP_ERROR_MESSAGE = "run is not allowed in the same step as a multi-platform build"
 
 
 class Config(BaseModel, extra="forbid"):
@@ -321,9 +322,7 @@ class Config(BaseModel, extra="forbid"):
                         )
 
                     if step.run:
-                        raise ValueError(
-                            f"run is not allowed with multi-platform build step {step_name}"
-                        )
+                        raise ValueError(f"{RUN_MP_ERROR_MESSAGE} {step_name}")
 
                     # Check for valid push section, duplicate mp tags are not allowed
                     validate_push(step.push, mp_push_tags, step_name)

--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -150,19 +150,25 @@ class Config(BaseModel, extra="forbid"):
             dockerfile_text = None
             src_image = []
             is_multi_platform = False
+            dockerfile = None
 
             # Gets the source image from build.dockerfile
-            if step.build and step.build.dockerfile:
-                if os.path.exists(step.build.dockerfile):
-                    with open(step.build.dockerfile, "r") as dockerfile:
-                        dockerfile_text = dockerfile.read()
-                else:
-                    # Dockerfile is defined as a string in the config file
-                    dockerfile_text = step.build.dockerfile
+            if step.build:
+                dockerfile = step.build.dockerfile
+                if not dockerfile and step.build.path:
+                    dockerfile = f"{step.build.path}/Dockerfile"
+
+                if dockerfile:
+                    if os.path.exists(dockerfile):
+                        with open(dockerfile, "r") as file:
+                            dockerfile_text = file.read()
+                    else:
+                        # Dockerfile is defined as a string in the config file
+                        dockerfile_text = dockerfile
 
                 if not dockerfile_text:
                     raise ValueError(
-                        f"There is an issue with the dockerfile {step.build.dockerfile}"
+                        f"There is an issue with the dockerfile {dockerfile}"
                     )
 
                 for line in dockerfile_text.splitlines():
@@ -174,7 +180,7 @@ class Config(BaseModel, extra="forbid"):
 
                 if not src_image:
                     raise ValueError(
-                        f"There is an issue with the dockerfile {step.build.dockerfile}"
+                        f"There is an issue with the dockerfile {dockerfile}"
                     )
 
             # Get the source image from step.run.image

--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -6,6 +6,7 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in accordance
 with the terms of the Adobe license agreement accompanying it.
 """
 
+import os
 from typing import Any, Dict, List, Optional, Set, Union
 
 # pylint: disable=no-name-in-module
@@ -14,7 +15,9 @@ from pydantic import BaseModel, Field, field_validator, ValidationError
 from buildrunner.docker import multiplatform_image_builder
 from buildrunner.validation.errors import Errors, get_validation_errors
 from buildrunner.validation.step import Step, StepPushCommitDict
+from buildrunner.validation.step_images_info import StepImagesInfo
 
+RETAG_ERROR_MESSAGE = "Multi-platform build steps cannot re-tag images. The following images are re-tagged:"
 
 class Config(BaseModel, extra="forbid"):
     """Top level config model"""
@@ -110,18 +113,19 @@ class Config(BaseModel, extra="forbid"):
                         name = f"{name}:latest"
 
                 if isinstance(push, StepPushCommitDict):
-                    names = [f"{push.repository}:{tag}" for tag in push.tags]
+                    if not push.tags:
+                        name = f'{push.repository}:latest'
+                    else:
+                        names = [f"{push.repository}:{tag}" for tag in push.tags]
 
                 if names is not None:
                     for current_name in names:
                         if current_name in mp_push_tags:
-                            # raise ValueError(f'Cannot specify duplicate tag {current_name} in build step {step_name}')
                             raise ValueError(
                                 f"Cannot specify duplicate tag {current_name} in build step {step_name}"
                             )
 
                 if name is not None and name in mp_push_tags:
-                    # raise ValueError(f'Cannot specify duplicate tag {name} in build step {step_name}')
                     raise ValueError(
                         f"Cannot specify duplicate tag {name} in build step {step_name}"
                     )
@@ -131,6 +135,134 @@ class Config(BaseModel, extra="forbid"):
 
                 if update_mp_push_tags and name is not None:
                     mp_push_tags.add(name)
+
+        def get_source_image(step: Step) -> Optional[List[str]]:
+            """
+            Get the source image from the step.build and/or step.run.image
+
+            Args:
+                step (Step): Build step
+
+            Returns:
+                Optional[str]: Source images
+            """
+            dockerfile_text = None
+            src_image = []
+            is_multi_platform = False
+
+            # Gets the source image from build.dockerfile
+            if step.build and step.build.dockerfile:
+                if os.path.exists(step.build.dockerfile):
+                    with open(step.build.dockerfile, "r") as dockerfile:
+                        dockerfile_text = dockerfile.read()
+                else:
+                    # Dockerfile is defined as a string in the config file
+                    dockerfile_text = step.build.dockerfile
+
+                if not dockerfile_text:
+                    raise ValueError(
+                        f"There is an issue with the dockerfile {step.build.dockerfile}"
+                    )
+
+                for line in dockerfile_text.splitlines():
+                    if line.startswith("FROM"):
+                        image_name = line.replace("FROM ", "").strip()
+                        if ":" not in image_name:
+                            image_name = f"{image_name}:latest"
+                        src_image.append(image_name)
+
+                if not src_image:
+                    raise ValueError(
+                        f"There is an issue with the dockerfile {step.build.dockerfile}"
+                    )
+
+            # Get the source image from step.run.image
+            if step.run and step.run.image:
+                if ":" not in step.run.image:
+                    src_image.append(f"{step.run.image}:latest")
+                else:
+                    src_image.append(step.run.image)
+
+            if step.build and step.build.platforms:
+                is_multi_platform = True
+
+            return src_image, is_multi_platform
+
+        def get_destination_images(step: Step) -> Optional[List[str]]:
+            """
+            Get the destination images from step.push or step.commit
+
+            Args:
+                step (Step): Build step
+
+            Returns:
+                Optional[List[str]]: List of destination images
+            """
+            def get_images(pushcommmit: Union[StepPushCommitDict, str, List[Union[str, StepPushCommitDict]]]) -> List[str]:
+                images = []
+                if isinstance(pushcommmit, StepPushCommitDict):
+                    if pushcommmit.tags:
+                        for tag in pushcommmit.tags:
+                            images.append(f"{pushcommmit.repository}:{tag}")
+                    else:
+                        images.append(f"{pushcommmit.repository}:latest")
+                elif isinstance(pushcommmit, str):
+                    if ":" not in pushcommmit:
+                        images.append(f"{pushcommmit}:latest")
+                    else:
+                        images.append(pushcommmit)
+                elif isinstance(pushcommmit, list):
+                    for item in pushcommmit:
+                        if isinstance(item, str):
+                            images.append(item)
+                        elif isinstance(item, StepPushCommitDict):
+                            if item.tags:
+                                for tag in item.tags:
+                                    images.append(f"{item.repository}:{tag}")
+                            else:
+                                images.append(f"{item.repository}:latest")
+                        else:
+                            raise ValueError(f"Unknown type for step.push: {type(step.push)}")
+                return images
+
+            images = []
+            images.extend(get_images(step.push))
+            images.extend(get_images(step.commit))
+            return images
+
+        def validate_multiplatform_are_not_retagged():
+            """
+            Validate multi-platform are not re-tagged
+
+            Args:
+                mp_push_tags (Set[str]): Set of all tags used in multi-platform build steps
+
+            Raises:
+                ValueError | pydantic.ValidationError: If the config file is invalid
+            """
+            step_images = {}
+
+            # Iterate through each step and get information about the images
+            for step_name, step in vals.items():
+                src_image, is_multi_platform = get_source_image(step)
+                dst_images = get_destination_images(step)
+                step_images[step_name] = StepImagesInfo(
+                    source_image=src_image,
+                    dest_images=dst_images,
+                    is_multi_platform=is_multi_platform)
+
+            # Iterate through each step images and check for multi-platform re-tagging
+            retagged_images = []
+            for step_name, step_images_info in step_images.items():
+                other_steps_images_infos = [curr_step_images_info for curr_step_name, curr_step_images_info in step_images.items() if curr_step_name != step_name]
+                for other_step_info in other_steps_images_infos:
+                    for src_image in step_images_info.source_image:
+                        if src_image in other_step_info.dest_images and other_step_info.is_multi_platform:
+                            retagged_images.append(src_image)
+
+            if retagged_images:
+                raise ValueError(f"{RETAG_ERROR_MESSAGE} {retagged_images}")
+
 
         def validate_multi_platform_build(mp_push_tags: Set[str]):
             """
@@ -142,7 +274,7 @@ class Config(BaseModel, extra="forbid"):
             Raises:
                 ValueError | pydantic.ValidationError: If the config file is invalid
             """
-            # Iterate through each step
+            # Iterate through each step and validate multi-platform multi-platform steps
             for step_name, step in vals.items():
                 if step.is_multi_platform():
                     if step.build.platform is not None:
@@ -166,9 +298,17 @@ class Config(BaseModel, extra="forbid"):
                             f"import is not allowed in multi-platform build step {step_name}"
                         )
 
+                    if step.run:
+                        raise ValueError(
+                            f"run is not allowed with multi-platform build step {step_name}"
+                        )
+
                     # Check for valid push section, duplicate mp tags are not allowed
                     validate_push(step.push, mp_push_tags, step_name)
 
+            validate_multiplatform_are_not_retagged()
+
+        # Checks to see if there is a mutli-platform build step in the config
         has_multi_platform_build = False
         for step in vals.values():
             has_multi_platform_build = (

--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -272,6 +272,7 @@ class Config(BaseModel, extra="forbid"):
                     for src_image in step_images_info.source_image:
                         if (
                             src_image in other_step_info.dest_images
+                            and step_images_info.dest_images
                             and other_step_info.is_multi_platform
                         ):
                             retagged_images.append(src_image)

--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -19,6 +19,7 @@ from buildrunner.validation.step_images_info import StepImagesInfo
 
 RETAG_ERROR_MESSAGE = "Multi-platform build steps cannot re-tag images. The following images are re-tagged:"
 
+
 class Config(BaseModel, extra="forbid"):
     """Top level config model"""
 
@@ -114,7 +115,7 @@ class Config(BaseModel, extra="forbid"):
 
                 if isinstance(push, StepPushCommitDict):
                     if not push.tags:
-                        name = f'{push.repository}:latest'
+                        name = f"{push.repository}:latest"
                     else:
                         names = [f"{push.repository}:{tag}" for tag in push.tags]
 
@@ -198,7 +199,12 @@ class Config(BaseModel, extra="forbid"):
             Returns:
                 Optional[List[str]]: List of destination images
             """
-            def get_images(pushcommmit: Union[StepPushCommitDict, str, List[Union[str, StepPushCommitDict]]]) -> List[str]:
+
+            def get_images(
+                pushcommmit: Union[
+                    StepPushCommitDict, str, List[Union[str, StepPushCommitDict]]
+                ],
+            ) -> List[str]:
                 images = []
                 if isinstance(pushcommmit, StepPushCommitDict):
                     if pushcommmit.tags:
@@ -222,7 +228,9 @@ class Config(BaseModel, extra="forbid"):
                             else:
                                 images.append(f"{item.repository}:latest")
                         else:
-                            raise ValueError(f"Unknown type for step.push: {type(step.push)}")
+                            raise ValueError(
+                                f"Unknown type for step.push: {type(step.push)}"
+                            )
                 return images
 
             images = []
@@ -249,20 +257,27 @@ class Config(BaseModel, extra="forbid"):
                 step_images[step_name] = StepImagesInfo(
                     source_image=src_image,
                     dest_images=dst_images,
-                    is_multi_platform=is_multi_platform)
+                    is_multi_platform=is_multi_platform,
+                )
 
             # Iterate through each step images and check for multi-platform re-tagging
             retagged_images = []
             for step_name, step_images_info in step_images.items():
-                other_steps_images_infos = [curr_step_images_info for curr_step_name, curr_step_images_info in step_images.items() if curr_step_name != step_name]
+                other_steps_images_infos = [
+                    curr_step_images_info
+                    for curr_step_name, curr_step_images_info in step_images.items()
+                    if curr_step_name != step_name
+                ]
                 for other_step_info in other_steps_images_infos:
                     for src_image in step_images_info.source_image:
-                        if src_image in other_step_info.dest_images and other_step_info.is_multi_platform:
+                        if (
+                            src_image in other_step_info.dest_images
+                            and other_step_info.is_multi_platform
+                        ):
                             retagged_images.append(src_image)
 
             if retagged_images:
                 raise ValueError(f"{RETAG_ERROR_MESSAGE} {retagged_images}")
-
 
         def validate_multi_platform_build(mp_push_tags: Set[str]):
             """

--- a/buildrunner/validation/step_images_info.py
+++ b/buildrunner/validation/step_images_info.py
@@ -1,0 +1,31 @@
+"""
+Copyright 2024 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in accordance
+with the terms of the Adobe license agreement accompanying it.
+"""
+from typing import List
+
+
+class StepImagesInfo():
+
+    def __init__(self,
+                 source_image: str,
+                 dest_images: List[str],
+                 is_multi_platform: bool) -> None:
+        self._is_multi_platform = is_multi_platform
+        self._source_image = source_image
+        self._dest_images = dest_images
+
+    @property
+    def is_multi_platform(self) -> bool:
+        return self._is_multi_platform
+
+    @property
+    def source_image(self) -> str:
+        return self._source_image
+
+    @property
+    def dest_images(self) -> list:
+        return self._dest_images

--- a/buildrunner/validation/step_images_info.py
+++ b/buildrunner/validation/step_images_info.py
@@ -8,12 +8,10 @@ with the terms of the Adobe license agreement accompanying it.
 from typing import List
 
 
-class StepImagesInfo():
-
-    def __init__(self,
-                 source_image: str,
-                 dest_images: List[str],
-                 is_multi_platform: bool) -> None:
+class StepImagesInfo:
+    def __init__(
+        self, source_image: str, dest_images: List[str], is_multi_platform: bool
+    ) -> None:
         self._is_multi_platform = is_multi_platform
         self._source_image = source_image
         self._dest_images = dest_images

--- a/tests/test-files/test-multi-platform-image-reuse.yaml
+++ b/tests/test-files/test-multi-platform-image-reuse.yaml
@@ -12,9 +12,6 @@ steps:
       tags: [ 'latest', '0.0.1' ]
     - repository: user2/buildrunner-test-multi-platform
       tags: [ 'latest', '0.0.1' ]
-    run:
-      image: user1/buildrunner-test-multi-platform:0.0.1
-      cmd: echo "Hello World"
 
   use-built-image1:
     run:

--- a/tests/test_config_validation/Dockerfile.retag
+++ b/tests/test_config_validation/Dockerfile.retag
@@ -1,0 +1,1 @@
+FROM busybox:latest

--- a/tests/test_config_validation/test_multi_platform.py
+++ b/tests/test_config_validation/test_multi_platform.py
@@ -1,0 +1,46 @@
+
+import yaml
+from buildrunner.validation.config import validate_config, Errors
+
+
+def test_no_run_with_multiplatform_build():
+    # Run in multi platform build is not supported
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push:
+                repository: user1/buildrunner-test-multi-platform
+                tags: []
+            run:
+                image: user1/buildrunner-test-multi-platform
+                cmd: echo "Hello World"
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+def test_no_run_with_single_build():
+    # Run in single platform build is supported
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+            push:
+                repository: user1/buildrunner-test-multi-platform
+                tags: []
+            run:
+                image: user1/buildrunner-test-multi-platform
+                cmd: echo "Hello World"
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert errors is None

--- a/tests/test_config_validation/test_multi_platform.py
+++ b/tests/test_config_validation/test_multi_platform.py
@@ -1,4 +1,3 @@
-
 import yaml
 from buildrunner.validation.config import validate_config, Errors
 
@@ -25,6 +24,7 @@ def test_no_run_with_multiplatform_build():
     errors = validate_config(**config)
     assert isinstance(errors, Errors)
     assert errors.count() == 1
+
 
 def test_no_run_with_single_build():
     # Run in single platform build is supported

--- a/tests/test_config_validation/test_multi_platform.py
+++ b/tests/test_config_validation/test_multi_platform.py
@@ -1,5 +1,5 @@
 import yaml
-from buildrunner.validation.config import validate_config, Errors
+from buildrunner.validation.config import validate_config, Errors, RUN_MP_ERROR_MESSAGE
 
 
 def test_no_run_with_multiplatform_build():
@@ -30,7 +30,7 @@ def test_no_run_with_single_build():
     # Run in single platform build is supported
     config_yaml = """
     steps:
-        build-container-multi-platform:
+        build-container:
             build:
                 dockerfile: |
                     FROM {{ DOCKER_REGISTRY }}/busybox:latest
@@ -40,6 +40,43 @@ def test_no_run_with_single_build():
             run:
                 image: user1/buildrunner-test-multi-platform
                 cmd: echo "Hello World"
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert errors is None
+
+
+def test_invalid_post_build():
+    # Post build is not supported for multi platform builds
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            run:
+                post-build: path/to/build/context
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+    assert RUN_MP_ERROR_MESSAGE in errors.errors[0].message
+
+
+def test_valid_post_build():
+    # Post build is supported for single platform builds
+    config_yaml = """
+    steps:
+        build-container-single-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+            run:
+                post-build: path/to/build/context
     """
     config = yaml.load(config_yaml, Loader=yaml.Loader)
     errors = validate_config(**config)

--- a/tests/test_config_validation/test_multi_platform.py
+++ b/tests/test_config_validation/test_multi_platform.py
@@ -9,7 +9,7 @@ def test_no_run_with_multiplatform_build():
         build-container-multi-platform:
             build:
                 dockerfile: |
-                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                    FROM {{DOCKER_REGISTRY}}/busybox:latest
                 platforms:
                     - linux/amd64
                     - linux/arm64/v8
@@ -33,7 +33,7 @@ def test_no_run_with_single_build():
         build-container:
             build:
                 dockerfile: |
-                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                    FROM {{DOCKER_REGISTRY}}/busybox:latest
             push:
                 repository: user1/buildrunner-test-multi-platform
                 tags: []

--- a/tests/test_config_validation/test_retagging.py
+++ b/tests/test_config_validation/test_retagging.py
@@ -1,0 +1,241 @@
+import yaml
+from buildrunner.validation.config import validate_config, Errors, RETAG_ERROR_MESSAGE
+
+
+def test_invalid_multiplatform_retagging_with_push():
+    # Retagging a multiplatform image is not supported
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push: user1/buildrunner-multi-platform-image:latest
+        retag-multi-platform-image:
+            run:
+                image: user1/buildrunner-multi-platform-image:latest
+                cmd: echo "Hello World"
+            push: user1/buildrunner-multi-platform-image2:latest
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+def test_invalid_multiplatform_retagging_latest_tag():
+    # Retagging a multiplatform image is not supported
+    # Tests adding 'latest' tag when left out
+
+    # Tests adding 'latest' tag to build.push
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push: user1/buildrunner-multi-platform-image
+        retag-multi-platform-image:
+            run:
+                image: user1/buildrunner-multi-platform-image:latest
+                cmd: echo "Hello World"
+            push: user1/buildrunner-multi-platform-image2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+    # Tests adding 'latest' tag to run.image
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push: user1/buildrunner-multi-platform-image:latest
+        retag-multi-platform-image:
+            run:
+                image: user1/buildrunner-multi-platform-image
+                cmd: echo "Hello World"
+            push: user1/buildrunner-multi-platform-image2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+    # Tests adding 'latest' tag to build.push and run.image
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push: user1/buildrunner-multi-platform-image
+        retag-multi-platform-image:
+            run:
+                image: user1/buildrunner-multi-platform-image
+                cmd: echo "Hello World"
+            push: user1/buildrunner-multi-platform-image2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+def test_invalid_multiplatform_retagging_with_push_empty_tags():
+    # Retagging a multiplatform image is not supported
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push:
+                repository: user1/buildrunner-test-multi-platform
+                tags: []
+
+        retag-built-image:
+            run:
+                image: user1/buildrunner-test-multi-platform
+                cmd: echo "Hello World"
+            push:
+                repository: user1/buildrunner-test-multi-platform2
+                tags: []
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+def test_invalid_multiplatform_retagging_with_commit():
+    # Retagging a multiplatform image is not supported
+    # Tests with commit in build step
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            commit: user1/buildrunner-multi-platform-image
+        retag-multi-platform-image:
+            run:
+                image: user1/buildrunner-multi-platform-image
+                command: echo "Hello World"
+            push: user1/buildrunner-multi-platform-image2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+def test_invalid_multiplatform_retagging_with_commit2():
+    # Retagging a multiplatform image is not supported
+    # Tests with commit after build step
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push: user1/buildrunner-test-multi-platform
+
+        retag-built-image:
+            run:
+                image: user1/buildrunner-test-multi-platform
+                cmd: echo "Hello World"
+            commit: user1/buildrunner-test-multi-platform2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+def test_valid_single_platform_retagging():
+    # Retagging a single platform image is supported
+    config_yaml = """
+    steps:
+        build-container-single-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+            push: user1/buildrunner-test-single-platform:latest
+
+        retag-built-image:
+            run:
+                image: user1/buildrunner-test-single-platform:latest
+                cmd: echo "Hello World"
+            push: user1/buildrunner-test-single-platform2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert errors is None
+
+def test_invalid_multiplatform_rebuild_and_push():
+    # Retagging a multiplatform image is not supported
+    # Tests reading from dockerfile for the 2nd dockerfile
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM busybox:latest
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push: user1/buildrunner-multi-platform-image
+        retag-multi-platform-image:
+            build:
+                dockerfile: |
+                    FROM user1/buildrunner-multi-platform-image
+            push: user1/buildrunner-multi-platform-image2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+
+def test_invalid_multiplatform_from_dockerfile_in_filesystem():
+    # Retagging a multiplatform image is not supported
+    # Tests reading from dockerfile for the 2nd dockerfile
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: tests/test_config_validation/Dockerfile.retag
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push: user1/buildrunner-multi-platform-image
+        retag-multi-platform-image:
+            build:
+                dockerfile: |
+                    FROM user1/buildrunner-multi-platform-image
+            push: user1/buildrunner-multi-platform-image2
+    """
+    config = yaml.load(config_yaml, Loader=yaml.Loader)
+    errors = validate_config(**config)
+    assert isinstance(errors, Errors)
+    assert errors.count() == 1
+    assert RETAG_ERROR_MESSAGE in errors.errors[0].message

--- a/tests/test_config_validation/test_retagging.py
+++ b/tests/test_config_validation/test_retagging.py
@@ -25,6 +25,7 @@ def test_invalid_multiplatform_retagging_with_push():
     assert isinstance(errors, Errors)
     assert errors.count() == 1
 
+
 def test_invalid_multiplatform_retagging_latest_tag():
     # Retagging a multiplatform image is not supported
     # Tests adding 'latest' tag when left out
@@ -95,6 +96,7 @@ def test_invalid_multiplatform_retagging_latest_tag():
     assert isinstance(errors, Errors)
     assert errors.count() == 1
 
+
 def test_invalid_multiplatform_retagging_with_push_empty_tags():
     # Retagging a multiplatform image is not supported
     config_yaml = """
@@ -123,6 +125,7 @@ def test_invalid_multiplatform_retagging_with_push_empty_tags():
     assert isinstance(errors, Errors)
     assert errors.count() == 1
 
+
 def test_invalid_multiplatform_retagging_with_commit():
     # Retagging a multiplatform image is not supported
     # Tests with commit in build step
@@ -146,6 +149,7 @@ def test_invalid_multiplatform_retagging_with_commit():
     errors = validate_config(**config)
     assert isinstance(errors, Errors)
     assert errors.count() == 1
+
 
 def test_invalid_multiplatform_retagging_with_commit2():
     # Retagging a multiplatform image is not supported
@@ -172,6 +176,7 @@ def test_invalid_multiplatform_retagging_with_commit2():
     assert isinstance(errors, Errors)
     assert errors.count() == 1
 
+
 def test_valid_single_platform_retagging():
     # Retagging a single platform image is supported
     config_yaml = """
@@ -191,6 +196,7 @@ def test_valid_single_platform_retagging():
     config = yaml.load(config_yaml, Loader=yaml.Loader)
     errors = validate_config(**config)
     assert errors is None
+
 
 def test_invalid_multiplatform_rebuild_and_push():
     # Retagging a multiplatform image is not supported
@@ -215,6 +221,7 @@ def test_invalid_multiplatform_rebuild_and_push():
     errors = validate_config(**config)
     assert isinstance(errors, Errors)
     assert errors.count() == 1
+
 
 def test_invalid_multiplatform_from_dockerfile_in_filesystem():
     # Retagging a multiplatform image is not supported

--- a/tests/test_config_validation/test_retagging.py
+++ b/tests/test_config_validation/test_retagging.py
@@ -29,8 +29,6 @@ def test_invalid_multiplatform_retagging_with_push():
 def test_invalid_multiplatform_retagging_latest_tag():
     # Retagging a multiplatform image is not supported
     # Tests adding 'latest' tag when left out
-
-    # Tests adding 'latest' tag to build.push
     config_yaml = """
     steps:
         build-container-multi-platform:
@@ -49,52 +47,7 @@ def test_invalid_multiplatform_retagging_latest_tag():
     """
     config = yaml.load(config_yaml, Loader=yaml.Loader)
     errors = validate_config(**config)
-    assert isinstance(errors, Errors)
-    assert errors.count() == 1
-
-    # Tests adding 'latest' tag to run.image
-    config_yaml = """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM busybox:latest
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image:latest
-        retag-multi-platform-image:
-            run:
-                image: user1/buildrunner-multi-platform-image
-                cmd: echo "Hello World"
-            push: user1/buildrunner-multi-platform-image2
-    """
-    config = yaml.load(config_yaml, Loader=yaml.Loader)
-    errors = validate_config(**config)
-    assert isinstance(errors, Errors)
-    assert errors.count() == 1
-
-    # Tests adding 'latest' tag to build.push and run.image
-    config_yaml = """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM busybox:latest
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image
-        retag-multi-platform-image:
-            run:
-                image: user1/buildrunner-multi-platform-image
-                cmd: echo "Hello World"
-            push: user1/buildrunner-multi-platform-image2
-    """
-    config = yaml.load(config_yaml, Loader=yaml.Loader)
-    errors = validate_config(**config)
-    assert isinstance(errors, Errors)
-    assert errors.count() == 1
+    assert errors is None
 
 
 def test_invalid_multiplatform_retagging_with_push_empty_tags():
@@ -104,7 +57,7 @@ def test_invalid_multiplatform_retagging_with_push_empty_tags():
         build-container-multi-platform:
             build:
                 dockerfile: |
-                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                    FROM {{DOCKER_REGISTRY}}/busybox:latest
                 platforms:
                     - linux/amd64
                     - linux/arm64/v8
@@ -159,7 +112,7 @@ def test_invalid_multiplatform_retagging_with_commit2():
         build-container-multi-platform:
             build:
                 dockerfile: |
-                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                    FROM {{DOCKER_REGISTRY}}/busybox:latest
                 platforms:
                     - linux/amd64
                     - linux/arm64/v8
@@ -184,7 +137,7 @@ def test_valid_single_platform_retagging():
         build-container-single-platform:
             build:
                 dockerfile: |
-                    FROM {{ DOCKER_REGISTRY }}/busybox:latest
+                    FROM {{DOCKER_REGISTRY}}/busybox:latest
             push: user1/buildrunner-test-single-platform:latest
 
         retag-built-image:
@@ -210,7 +163,7 @@ def test_invalid_multiplatform_rebuild_and_push():
                 platforms:
                     - linux/amd64
                     - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image
+            push: user1/buildrunner-multi-platform-image:latest
         retag-multi-platform-image:
             build:
                 dockerfile: |
@@ -234,7 +187,7 @@ def test_invalid_multiplatform_from_dockerfile_in_filesystem():
                 platforms:
                     - linux/amd64
                     - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image
+            push: user1/buildrunner-multi-platform-image:latest
         retag-multi-platform-image:
             build:
                 dockerfile: |
@@ -255,7 +208,7 @@ def test_reusing_multi_platform_images():
         build-container-multi-platform:
             build:
                 dockerfile: |
-                    FROM {{ DOCKER_REGISTRY }}/busybox
+                    FROM {{DOCKER_REGISTRY}}/busybox
                 platforms:
                     - linux/amd64
                     - linux/arm64/v8

--- a/tests/test_config_validation/test_validation_step.py
+++ b/tests/test_config_validation/test_validation_step.py
@@ -205,12 +205,16 @@ def test_duplicate_mp_tags_strings_valid():
     steps:
       build-container-multi-platform1:
         build:
+          dockerfile: |
+            FROM busybox:latest
           platforms:
             - linux/amd64
             - linux/arm64
         push: mytest-reg/buildrunner-test-multi-platform:latest
       build-container-multi-platform2:
         build:
+          dockerfile: |
+            FROM busybox:latest
           platforms:
             - linux/amd64
             - linux/arm64


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Performs configuration validation checks on multi-platform builds to ensure that re-tagging built multi-platform images in a subsequent step is not allowed. This is because non-deterministic behavior can occur if re-tagging is allowed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.