### PR TITLE
Add check and tests for automatic buildrunner id image tag

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -237,7 +237,9 @@ class BuildRunner:  # pylint: disable=too-many-instance-attributes
         if not _run_config_file or not os.path.exists(_run_config_file):
             raise BuildRunnerConfigurationError("Cannot find build configuration file")
 
-        self.run_config = self.global_config.load_config(_run_config_file)
+        self.run_config = self.global_config.load_config(
+            cfg_file=_run_config_file, default_tag=sanitize_tag(self.build_id)
+        )
 
         if not isinstance(self.run_config, dict) or "steps" not in self.run_config:
             cfg_file = _run_config_file if _run_config_file else "provided config"

--- a/buildrunner/steprunner/tasks/push.py
+++ b/buildrunner/steprunner/tasks/push.py
@@ -101,10 +101,6 @@ class PushBuildStepRunnerTask(BuildStepRunnerTask):
             self._repos = [self._get_repo_definition(config)]
 
     def run(self, context):  # pylint: disable=too-many-branches
-        # Determine internal tag based on source control information and build number
-        # Note: do not log sanitization as it would need to happen almost every time
-        default_tag = sanitize_tag(self.step_runner.build_runner.build_id)
-
         # Tag multi-platform images
         built_image = context.get("mp_built_image")
         if built_image:
@@ -118,8 +114,6 @@ class PushBuildStepRunnerTask(BuildStepRunnerTask):
             ]
 
             for repo in self._repos:
-                # Always add default tag and then add it to the built image info
-                repo.tags.append(default_tag)
                 tagged_image = built_image.add_tagged_image(repo.repository, repo.tags)
 
                 # Add tagged image refs to committed images for use in determining if pull should be true/false
@@ -166,9 +160,6 @@ class PushBuildStepRunnerTask(BuildStepRunnerTask):
             self.step_runner.build_runner.generated_images.append(image_to_use)
 
             for repo in self._repos:
-                # Always add default tag
-                repo.tags.append(default_tag)
-
                 if self._commit_only:
                     self.step_runner.log.write(
                         f'Committing resulting image as "{repo.repository}" with tags {", ".join(repo.tags)}.\n'

--- a/tests/test_config_validation/test_retagging.py
+++ b/tests/test_config_validation/test_retagging.py
@@ -1,5 +1,15 @@
+import os
+import tempfile
+from unittest import mock
+import pytest
 import yaml
+from buildrunner import BuildRunner
+from buildrunner.errors import BuildRunnerConfigurationError
 from buildrunner.validation.config import validate_config, Errors, RETAG_ERROR_MESSAGE
+
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+BLANK_GLOBAL_CONFIG = os.path.join(TEST_DIR, "files/blank_global_config.yaml")
 
 
 def test_invalid_multiplatform_retagging_with_push():
@@ -231,3 +241,191 @@ def test_reusing_multi_platform_images():
     config = yaml.load(config_yaml, Loader=yaml.Loader)
     errors = validate_config(**config)
     assert errors is None
+
+
+@mock.patch("buildrunner.config.DEFAULT_GLOBAL_CONFIG_FILES", [])
+@mock.patch("buildrunner.detect_vcs")
+def test_valid_retagging_jinja_template(detect_vcs_mock):
+    # Tests that "BUILDRUNNER_BUILD_DOCKER_TAG" is replaced with id_string-build_number
+
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push:
+                - repository: user1/buildrunner-test-multi-platform
+                  tags: [ 'latest', '0.0.1', {{ BUILDRUNNER_BUILD_DOCKER_TAG }} ]
+
+        use-built-image1:
+            run:
+                image: user1/buildrunner-test-multi-platform
+                cmd: echo "Hello World"
+    """
+
+    id_string = "main-921.ie02ed8.m1705616822"
+    build_number = 342
+    type(detect_vcs_mock.return_value).id_string = mock.PropertyMock(
+        return_value=id_string
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.NamedTemporaryFile(
+            dir=tmpdirname, mode="w", delete=False
+        ) as tmpfile:
+            tmpfile.write(config_yaml)
+            tmpfile.close()
+            try:
+                runner = BuildRunner(
+                    build_dir=tmpdirname,
+                    build_results_dir=tmpdirname,
+                    global_config_file=None,
+                    run_config_file=tmpfile.name,
+                    build_time=0,
+                    build_number=build_number,
+                    push=False,
+                    cleanup_images=False,
+                    cleanup_cache=False,
+                    steps_to_run=None,
+                    publish_ports=False,
+                    log_generated_files=False,
+                    docker_timeout=30,
+                    local_images=False,
+                    platform=None,
+                    disable_multi_platform=False,
+                )
+                config = runner.run_config
+                assert isinstance(config, dict)
+                assert f"{id_string}-{build_number}" in config.get("steps").get(
+                    "build-container-multi-platform"
+                ).get("push")[0].get("tags")
+            except Exception as e:
+                assert False, f"Unexpected exception raised: {e}"
+
+
+@mock.patch("buildrunner.config.DEFAULT_GLOBAL_CONFIG_FILES", [])
+@mock.patch("buildrunner.detect_vcs")
+def test_invalid_retagging_jinja_template_explicit(detect_vcs_mock):
+    # Tests that BUILDRUNNER_BUILD_DOCKER_TAG is replaced and fails for re-tagging
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push:
+                - repository: user1/buildrunner-test-multi-platform
+                  tags: [ 'latest', '0.0.1', {{ BUILDRUNNER_BUILD_DOCKER_TAG }} ]
+
+        use-built-image1:
+            run:
+                image: user1/buildrunner-test-multi-platform:{{ BUILDRUNNER_BUILD_DOCKER_TAG }}
+                cmd: echo "Hello World"
+            push:
+                repository: user1/buildrunner-test-multi-platform2
+                tags: [ 'latest' ]
+    """
+    id_string = "main-921.ie02ed8.m1705616822"
+    build_number = 342
+    type(detect_vcs_mock.return_value).id_string = mock.PropertyMock(
+        return_value=id_string
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.NamedTemporaryFile(
+            dir=tmpdirname, mode="w", delete=False
+        ) as tmpfile:
+            tmpfile.write(config_yaml)
+            tmpfile.close()
+            with pytest.raises(BuildRunnerConfigurationError) as excinfo:
+                BuildRunner(
+                    build_dir=tmpdirname,
+                    build_results_dir=tmpdirname,
+                    global_config_file=None,
+                    run_config_file=tmpfile.name,
+                    build_time=0,
+                    build_number=build_number,
+                    push=False,
+                    cleanup_images=False,
+                    cleanup_cache=False,
+                    steps_to_run=None,
+                    publish_ports=False,
+                    log_generated_files=False,
+                    docker_timeout=30,
+                    local_images=False,
+                    platform=None,
+                    disable_multi_platform=False,
+                )
+            assert RETAG_ERROR_MESSAGE in excinfo.value.args[0]
+            assert (
+                f"user1/buildrunner-test-multi-platform:{id_string}-{build_number}"
+                in excinfo.value.args[0]
+            )
+
+
+@mock.patch("buildrunner.config.DEFAULT_GLOBAL_CONFIG_FILES", [])
+@mock.patch("buildrunner.detect_vcs")
+def test_invalid_retagging_jinja_template_implied(detect_vcs_mock):
+    # Tests that BUILDRUNNER_BUILD_DOCKER_TAG is added to push tags abd fails for re-tagging
+    config_yaml = """
+    steps:
+        build-container-multi-platform:
+            build:
+                dockerfile: |
+                    FROM {{ DOCKER_REGISTRY }}/busybox
+                platforms:
+                    - linux/amd64
+                    - linux/arm64/v8
+            push:
+                - repository: user1/buildrunner-test-multi-platform
+                  tags: [ 'latest', '0.0.1' ]
+
+        use-built-image1:
+            run:
+                image: user1/buildrunner-test-multi-platform:{{ BUILDRUNNER_BUILD_DOCKER_TAG }}
+                cmd: echo "Hello World"
+            push: user1/buildrunner-test-multi-platform2
+    """
+    id_string = "main-921.ie02ed8.m1705616822"
+    build_number = 342
+    type(detect_vcs_mock.return_value).id_string = mock.PropertyMock(
+        return_value=id_string
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.NamedTemporaryFile(
+            dir=tmpdirname, mode="w", delete=False
+        ) as tmpfile:
+            tmpfile.write(config_yaml)
+            tmpfile.close()
+            with pytest.raises(BuildRunnerConfigurationError) as excinfo:
+                BuildRunner(
+                    build_dir=tmpdirname,
+                    build_results_dir=tmpdirname,
+                    global_config_file=None,
+                    run_config_file=tmpfile.name,
+                    build_time=0,
+                    build_number=build_number,
+                    push=False,
+                    cleanup_images=False,
+                    cleanup_cache=False,
+                    steps_to_run=None,
+                    publish_ports=False,
+                    log_generated_files=False,
+                    docker_timeout=30,
+                    local_images=False,
+                    platform=None,
+                    disable_multi_platform=False,
+                )
+            assert RETAG_ERROR_MESSAGE in excinfo.value.args[0]
+            assert (
+                f"user1/buildrunner-test-multi-platform:{id_string}-{build_number}"
+                in excinfo.value.args[0]
+            )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add more config validation. This change adds  multi-platform re-tagging checking for BUILDRUNNER_BUILD_DOCKER_TAG and jinja template in the config file. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.