### PR TITLE
Handle cases where multi-platform images are retagged in a mp step

### DIFF
--- a/buildrunner/validation/config.py
+++ b/buildrunner/validation/config.py
@@ -269,7 +269,12 @@ class Config(BaseModel, extra="forbid"):
             # Iterate through each step images and check for multi-platform re-tagging
             retagged_images = []
             for step_name, step_images_info in step_images.items():
-                if not step_images_info.dest_images:
+                if (
+                    # Ignore steps that do not push images
+                    not step_images_info.dest_images
+                    # Ignore steps that are also multi-platform, as re-tagging will work in this case
+                    or step_images_info.is_multi_platform
+                ):
                     continue
 
                 other_steps_images_infos = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle retagged image validation when the retagging step is also multiplatform.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The multiplatform retagging validation did not account for multiplatform steps doing the retagging, which is a valid use case.

## How Has This Been Tested?

Unit tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.