### PR TITLE
Do not save caches for a failed build

### DIFF
--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -1026,14 +1026,19 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
                         log_method = container_meta_logger.info
                     log_method(f'Command "{_cmd}" exited with code {exit_code}')
 
-                    if exit_code != 0:
+                    if exit_code:
                         break
             else:
                 self.runner.attach_until_finished(container_logger)
                 exit_code = self.runner.exit_code
                 container_meta_logger.write(f"Container exited with code {exit_code}\n")
 
-            self.runner.save_caches(container_meta_logger, caches)
+            if exit_code:
+                container_meta_logger.write(
+                    "Skipping cache save due to failed exit code"
+                )
+            else:
+                self.runner.save_caches(container_meta_logger, caches)
 
         finally:
             if self.runner:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?

Failed builds would sometimes cause corrupted causes to be saved and therefore cause all subsequent builds to fail in the same way. This prevents that issue by never saving the cache if the run fails for any reason.

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [ ] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

