### PR TITLE
XENG-7748 Add flag to disable default tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -850,6 +850,9 @@ step the image produced from the 'build' configuration is tagged and pushed.
 Any published Docker images are tagged with source tree branch and commit
 information as well as a provided or generated build number for tracking
 purposes. Additional tags may be added in the 'commit' or 'push' configuration.
+The default generated tag may be omitted by setting the 'add_build_tag' flag to
+false. In this case, the 'tags' property must be specified or else an error
+will occur.
 
 To push the image to a registry, you must add the --push argument to buildrunner.
 
@@ -876,6 +879,8 @@ The configuration may also specify additional tags to add to the image:
       # To push the docker image to a registry
       push:
         repository: myimages/image1
+        # Do not include default build tag
+        add_build_tag: false
         tags: [ 'latest' ]
       # OR to just commit it locally to use in subsequent steps
       commit:

--- a/buildrunner/config/loader.py
+++ b/buildrunner/config/loader.py
@@ -62,7 +62,8 @@ def _add_default_tag_to_tags(config: Union[str, dict], default_tag: str) -> dict
         if not config.get("tags"):
             config["tags"] = []
         assert isinstance(config.get("tags"), list)
-        if default_tag not in config.get("tags"):
+        # Only add the tag if not disabled in the config
+        if config.get("add_build_tag", True) and default_tag not in config.get("tags"):
             config.get("tags").append(default_tag)
 
     # Convert to dictionary and add default tag if not listed already

--- a/buildrunner/config/models_step.py
+++ b/buildrunner/config/models_step.py
@@ -167,7 +167,11 @@ class StepPushCommit(StepTask):
     """Push model within a step"""
 
     repository: str
-    tags: Optional[List[str]] = None
+    add_build_tag: bool = True
+    tags: Optional[List[str]] = Field(
+        None,
+        min_length=1,
+    )
     push: bool
 
 

--- a/buildrunner/config/validation.py
+++ b/buildrunner/config/validation.py
@@ -146,6 +146,8 @@ def _get_source_image(step: Step) -> str:
     # Get the source image from step.run.image if build.dockerfile is not defined
     elif step.run and step.run.image:
         src_image = step.run.image
+        if ":" not in src_image:
+            src_image = f"{src_image}:latest"
 
     return src_image
 

--- a/buildrunner/docker/builder.py
+++ b/buildrunner/docker/builder.py
@@ -183,6 +183,6 @@ class DockerBuilder:  # pylint: disable=too-many-instance-attributes
             try:
                 force_remove_container(self.docker_client, container)
             except docker.errors.APIError as err:
-                logger.warning(
+                logger.debug(
                     f"Error removing intermediate container {container}: {err}"
                 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = "3.5"
+BASE_VERSION = "3.6"
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BUILDRUNNER_DIR = os.path.join(SOURCE_DIR, "buildrunner")

--- a/tests/test-files/test-push.yaml
+++ b/tests/test-files/test-push.yaml
@@ -28,6 +28,22 @@ steps:
       - repository: adobe/buildrunner-test4
         tags: ["{{ BUILDRUNNER_BUILD_TIME }}"]
 
+  test-push-without-default-tag:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+    push:
+      repository: adobe/buildrunner-test5
+      add_build_tag: false
+      tags: [latest]
+
+  test-pull-latest-tag:
+    run:
+      image: adobe/buildrunner-test5:latest
+      pull: false
+      cmds:
+      - 'true'
+
   test-pull-build-defaults:
     build:
       # pull defaults to false

--- a/tests/test-files/test-push.yaml
+++ b/tests/test-files/test-push.yaml
@@ -28,18 +28,33 @@ steps:
       - repository: adobe/buildrunner-test4
         tags: ["{{ BUILDRUNNER_BUILD_TIME }}"]
 
-  test-push-without-default-tag:
+  test-push-without-default-tag1:
     build:
       dockerfile: |
         FROM {{ DOCKER_REGISTRY }}/busybox:latest
+      platforms:
+      - linux/amd64
+      - linux/arm64
     push:
       repository: adobe/buildrunner-test5
       add_build_tag: false
-      tags: [latest]
+      tags: [tag1]
+
+  test-push-without-default-tag2:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+      platforms:
+      - linux/amd64
+      - linux/arm64
+    push:
+      repository: adobe/buildrunner-test5
+      add_build_tag: false
+      tags: [tag2]
 
   test-pull-latest-tag:
     run:
-      image: adobe/buildrunner-test5:latest
+      image: adobe/buildrunner-test5:tag1
       pull: false
       cmds:
       - 'true'

--- a/tests/test_config_validation/test_multi_platform.py
+++ b/tests/test_config_validation/test_multi_platform.py
@@ -21,7 +21,7 @@ from buildrunner.config.validation import (
                     - linux/arm64/v8
             push:
                 repository: user1/buildrunner-test-multi-platform
-                tags: []
+                tags: ['latest']
             run:
                 image: user1/buildrunner-test-multi-platform
                 cmd: echo "Hello World"
@@ -40,7 +40,7 @@ from buildrunner.config.validation import (
                     FROM {{DOCKER_REGISTRY}}/busybox:latest
             push:
                 repository: user1/buildrunner-test-multi-platform
-                tags: []
+                tags: ['latest']
             run:
                 image: user1/buildrunner-test-multi-platform
                 cmd: echo "Hello World"

--- a/tests/test_config_validation/test_retagging.py
+++ b/tests/test_config_validation/test_retagging.py
@@ -14,53 +14,36 @@ BLANK_GLOBAL_CONFIG = os.path.join(TEST_DIR, "files/blank_global_config.yaml")
 
 
 @pytest.mark.parametrize(
-    "config_yaml, error_matches",
+    "desc, config_yaml, error_matches",
     [
-        # Retagging a multiplatform image is not supported
         (
+            "Retagging a multiplatform image is not supported",
             """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM busybox:latest
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image:latest
-        retag-multi-platform-image:
-            run:
-                image: user1/buildrunner-multi-platform-image:latest
-                cmd: echo "Hello World"
-            push: user1/buildrunner-multi-platform-image2:latest
-    """,
+        steps:
+            build-container-multi-platform:
+                build:
+                    dockerfile: |
+                        FROM busybox:latest
+                    platforms:
+                        - linux/amd64
+                        - linux/arm64/v8
+                push:
+                    repository: user1/buildrunner-multi-platform-image
+                    tags: [latest]
+            retag-multi-platform-image:
+                run:
+                    image: user1/buildrunner-multi-platform-image:latest
+                    cmd: echo "Hello World"
+                push:
+                    repository: user1/buildrunner-multi-platform-image2
+                    tags: [latest]
+        """,
             [
                 "The following images are re-tagged: ['user1/buildrunner-multi-platform-image:latest']"
             ],
         ),
-        # Retagging a multiplatform image is not supported
-        # Tests adding 'latest' tag when left out
         (
-            """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM busybox:latest
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image
-        retag-multi-platform-image:
-            run:
-                image: user1/buildrunner-multi-platform-image:latest
-                cmd: echo "Hello World"
-            push: user1/buildrunner-multi-platform-image2
-    """,
-            [],
-        ),
-        # Retagging a multiplatform image is not supported
-        (
+            "Latest tag is assumed if not specified in image",
             """
     steps:
         build-container-multi-platform:
@@ -72,7 +55,7 @@ BLANK_GLOBAL_CONFIG = os.path.join(TEST_DIR, "files/blank_global_config.yaml")
                     - linux/arm64/v8
             push:
                 repository: user1/buildrunner-test-multi-platform
-                tags: []
+                tags: [latest]
 
         retag-built-image:
             run:
@@ -80,154 +63,171 @@ BLANK_GLOBAL_CONFIG = os.path.join(TEST_DIR, "files/blank_global_config.yaml")
                 cmd: echo "Hello World"
             push:
                 repository: user1/buildrunner-test-multi-platform2
-                tags: []
+                tags: [latest]
     """,
             [
-                "The following images are re-tagged: ['user1/buildrunner-test-multi-platform']"
+                "The following images are re-tagged: ['user1/buildrunner-test-multi-platform:latest']"
             ],
         ),
-        # Retagging a multiplatform image is not supported
-        # Tests with commit in build step
         (
+            "Commit in build step",
             """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM busybox:latest
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            commit: user1/buildrunner-multi-platform-image
-        retag-multi-platform-image:
-            run:
-                image: user1/buildrunner-multi-platform-image
-                cmd: echo "Hello World"
-            push: user1/buildrunner-multi-platform-image2
-    """,
-            [
-                "The following images are re-tagged: ['user1/buildrunner-multi-platform-image']"
-            ],
-        ),
-        # Retagging a multiplatform image is not supported
-        # Tests with commit after build step
-        (
-            """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM {{DOCKER_REGISTRY}}/busybox:latest
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push: user1/buildrunner-test-multi-platform
-
-        retag-built-image:
-            run:
-                image: user1/buildrunner-test-multi-platform
-                cmd: echo "Hello World"
-            commit: user1/buildrunner-test-multi-platform2
-    """,
-            [
-                "The following images are re-tagged: ['user1/buildrunner-test-multi-platform']"
-            ],
-        ),
-        # Retagging a single platform image is supported
-        (
-            """
-    steps:
-        build-container-single-platform:
-            build:
-                dockerfile: |
-                    FROM {{DOCKER_REGISTRY}}/busybox:latest
-            push: user1/buildrunner-test-single-platform:latest
-
-        retag-built-image:
-            run:
-                image: user1/buildrunner-test-single-platform:latest
-                cmd: echo "Hello World"
-            push: user1/buildrunner-test-single-platform2
-    """,
-            [],
-        ),
-        # Retagging a multiplatform image is not supported
-        # Tests reading from dockerfile for the 2nd dockerfile
-        (
-            """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM busybox:latest
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image:latest
-        retag-multi-platform-image:
-            build:
-                dockerfile: |
-                    FROM user1/buildrunner-multi-platform-image
-            push: user1/buildrunner-multi-platform-image2
-    """,
+        steps:
+            build-container-multi-platform:
+                build:
+                    dockerfile: |
+                        FROM busybox:latest
+                    platforms:
+                        - linux/amd64
+                        - linux/arm64/v8
+                commit:
+                    repository: user1/buildrunner-multi-platform-image
+                    tags: [latest]
+            retag-multi-platform-image:
+                run:
+                    image: user1/buildrunner-multi-platform-image
+                    cmd: echo "Hello World"
+                push:
+                    repository: user1/buildrunner-multi-platform-image2
+                    tags: [latest]
+        """,
             [
                 "The following images are re-tagged: ['user1/buildrunner-multi-platform-image:latest']"
             ],
         ),
-        # Retagging a multiplatform image is not supported
-        # Tests reading from dockerfile for the 2nd dockerfile
         (
+            "Commit after build step",
             """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: tests/test_config_validation/Dockerfile.retag
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push: user1/buildrunner-multi-platform-image:latest
-        retag-multi-platform-image:
-            build:
-                dockerfile: |
-                    FROM user1/buildrunner-multi-platform-image
-            push: user1/buildrunner-multi-platform-image2
-    """,
+        steps:
+            build-container-multi-platform:
+                build:
+                    dockerfile: |
+                        FROM {{DOCKER_REGISTRY}}/busybox:latest
+                    platforms:
+                        - linux/amd64
+                        - linux/arm64/v8
+                push:
+                    repository: user1/buildrunner-test-multi-platform
+                    tags: [latest]
+
+            retag-built-image:
+                run:
+                    image: user1/buildrunner-test-multi-platform
+                    cmd: echo "Hello World"
+                commit:
+                    repository: user1/buildrunner-test-multi-platform2
+                    tags: [latest]
+        """,
+            [
+                "The following images are re-tagged: ['user1/buildrunner-test-multi-platform:latest']"
+            ],
+        ),
+        (
+            "Retagging a single platform image is supported",
+            """
+        steps:
+            build-container-single-platform:
+                build:
+                    dockerfile: |
+                        FROM {{DOCKER_REGISTRY}}/busybox:latest
+                push:
+                    repository: user1/buildrunner-test-single-platform
+                    tags: [latest]
+
+            retag-built-image:
+                run:
+                    image: user1/buildrunner-test-single-platform:latest
+                    cmd: echo "Hello World"
+                push:
+                    repository: user1/buildrunner-test-single-platform2
+                    tags: [latest]
+        """,
+            [],
+        ),
+        (
+            "Read from dockerfile for the 2nd dockerfile",
+            """
+        steps:
+            build-container-multi-platform:
+                build:
+                    dockerfile: |
+                        FROM busybox:latest
+                    platforms:
+                        - linux/amd64
+                        - linux/arm64/v8
+                push:
+                    repository: user1/buildrunner-multi-platform-image
+                    tags: [latest]
+            retag-multi-platform-image:
+                build:
+                    dockerfile: |
+                        FROM user1/buildrunner-multi-platform-image
+                push:
+                    repository: user1/buildrunner-multi-platform-image2
+                    tags: [latest]
+        """,
+            [
+                "The following images are re-tagged: ['user1/buildrunner-multi-platform-image:latest']"
+            ],
+        ),
+        (
+            "Read from dockerfile file",
+            """
+        steps:
+            build-container-multi-platform:
+                build:
+                    dockerfile: tests/test_config_validation/Dockerfile.retag
+                    platforms:
+                        - linux/amd64
+                        - linux/arm64/v8
+                push:
+                    repository: user1/buildrunner-multi-platform-image
+                    tags: [latest]
+            retag-multi-platform-image:
+                build:
+                    dockerfile: |
+                        FROM user1/buildrunner-multi-platform-image
+                push:
+                    repository: user1/buildrunner-multi-platform-image2
+                    tags: [latest]
+        """,
             [RETAG_ERROR_MESSAGE],
         ),
-        # Reuse multi-platform images is valid if the image isn't committed or pushed
         (
+            "Reuse multi-platform images is valid if the image isn't committed or pushed",
             """
-    steps:
-        build-container-multi-platform:
-            build:
-                dockerfile: |
-                    FROM {{DOCKER_REGISTRY}}/busybox
-                platforms:
-                    - linux/amd64
-                    - linux/arm64/v8
-            push:
-                - repository: user1/buildrunner-test-multi-platform
-                  tags: [ 'latest', '0.0.1' ]
-                - repository: user2/buildrunner-test-multi-platform
-                  tags: [ 'latest', '0.0.1' ]
+        steps:
+            build-container-multi-platform:
+                build:
+                    dockerfile: |
+                        FROM {{DOCKER_REGISTRY}}/busybox
+                    platforms:
+                        - linux/amd64
+                        - linux/arm64/v8
+                push:
+                    - repository: user1/buildrunner-test-multi-platform
+                      tags: [ 'latest', '0.0.1' ]
+                    - repository: user2/buildrunner-test-multi-platform
+                      tags: [ 'latest', '0.0.1' ]
 
-        use-built-image1:
-            run:
-                image: user1/buildrunner-test-multi-platform:0.0.1
-                cmd: echo "Hello World"
+            use-built-image1:
+                run:
+                    image: user1/buildrunner-test-multi-platform:0.0.1
+                    cmd: echo "Hello World"
 
-        use-built-image2:
-            run:
-                image: user2/buildrunner-test-multi-platform:0.0.1
-                cmd: echo "Hello World"
-    """,
+            use-built-image2:
+                run:
+                    image: user2/buildrunner-test-multi-platform:0.0.1
+                    cmd: echo "Hello World"
+        """,
             [],
         ),
     ],
 )
 def test_config_data(
-    config_yaml, error_matches, assert_generate_and_validate_config_errors
+    desc, config_yaml, error_matches, assert_generate_and_validate_config_errors
 ):
+    _ = desc
     assert_generate_and_validate_config_errors(config_yaml, error_matches)
 
 
@@ -287,7 +287,7 @@ def test_config_data(
                         RUN printf '{{ BUILDRUNNER_BUILD_NUMBER }}' > /usr/share/nginx/html/index.html
                 push:
                     repository:  user1/buildrunner-test-image
-                    tags: []
+                    tags: [latest]
     """,
         """
         steps:
@@ -298,6 +298,7 @@ def test_config_data(
                         RUN printf '{{ BUILDRUNNER_BUILD_NUMBER }}' > /usr/share/nginx/html/index.html
                 push:
                     repository: user1/buildrunner-test-image
+                    tags: [latest]
     """,
     ],
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
The default tag can conflict sometimes with multiple repositories named the same but with different tags. This allows that use case.

### Previous Behavior
Multiplatform builds would error if the same repo was used with different tags for different steps.

### New Behavior
There is no error in this case.

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

