### PR TITLE
Rename platform to architecture for env var

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -319,7 +319,8 @@ Buildrunner injects special environment variables and volume mounts into every
 run container. The following environment variables are set and available in
 every run container:
 
-:``BUILDRUNNER_PLATFORM``: the platform of the current device (x86_64, aarch64, etc), equivalent to ``platform.machine()``
+:``BUILDRUNNER_ARCHITECTURE``: the architecture of the current device (x86_64, aarch64, etc), equivalent to ``platform.machine()``
+:``BUILDRUNNER_PLATFORM``: (Deprecated, will be removed in favor of ``BUILDRUNNER_ARCHITECTURE``) the platform of the current device (x86_64, aarch64, etc), equivalent to ``platform.machine()``
 :``BUILDRUNNER_BUILD_NUMBER``: the build number
 :``BUILDRUNNER_BUILD_ID``: a unique id identifying the build (includes vcs and build number
                            information), e.g. "main-1791.Ia09cc5.M0-1661374484"

--- a/buildrunner/config/__init__.py
+++ b/buildrunner/config/__init__.py
@@ -178,12 +178,14 @@ class BuildRunnerConfig:
         """
 
         context = {
-            "BUILDRUNNER_PLATFORM": str(platform.machine()),
+            "BUILDRUNNER_ARCHITECTURE": str(platform.machine()),
             "BUILDRUNNER_BUILD_NUMBER": str(build_number),
             "BUILDRUNNER_BUILD_ID": str(build_id),
             "BUILDRUNNER_BUILD_DOCKER_TAG": str(self.default_tag),
             "BUILDRUNNER_BUILD_TIME": str(self.build_time),
             "BUILDRUNNER_STEPS": steps_to_run,
+            # Deprecated, remove after June 2024
+            "BUILDRUNNER_PLATFORM": str(platform.machine()),
         }
         if vcs:
             context.update(

--- a/tests/test-files/test-general.yaml
+++ b/tests/test-files/test-general.yaml
@@ -147,8 +147,8 @@ steps:
       image: {{ DOCKER_REGISTRY }}/centos:8
       cmd: 'if [ $(ls -laR /artifacts/setup-uncompress-dirs/ | grep tar.gz | wc -l) != 0 ]; then exit 1; fi'
 
-  test-platform:
+  test-architecture:
     run:
       image: {{ DOCKER_REGISTRY }}/centos:8
-      cmd: 'if [ -z "{{ BUILDRUNNER_PLATFORM }}" ]; then exit 1; else echo "Platform is {{ BUILDRUNNER_PLATFORM }}"; fi'
+      cmd: 'if [ -z "{{ BUILDRUNNER_ARCHITECTURE }}" ]; then exit 1; else echo "Architecture is {{ BUILDRUNNER_ARCHITECTURE }}"; fi'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
BUILDRUNNER_PLATFORM was poorly named, it needs to be BUILDRUNNER_ARCHITECTURE instead. This deprecates platform in favor of architecture.

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

