### PR TITLE
Add overrides for security scanning at the step level and fix handling for no build tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -882,10 +882,23 @@ The configuration may also specify additional tags to add to the image:
         # Do not include default build tag
         add_build_tag: false
         tags: [ 'latest' ]
+        # Optional security scan configuration may be provided for each configured push
+        security-scan:
+          # See docs/global-configuration.rst for more information on these attributes.
+          #enabled: false
+          #scanner: "trivy"
+          #version: "latest"
+          # NOTE: Any configuration provided here will be merged with global/command line config
+          #config:
+          #  optional-param: val1
+          # Set to a float to fail the build if the maximum score
+          # is greater than or equal to this number
+          #max-score-threshold: 8.9
       # OR to just commit it locally to use in subsequent steps
       commit:
         repository: myimages/image1
         tags: [ 'latest' ]
+        # NOTE: Image security scans are disabled for images that are not pushed
 
 The configuration may also specify multiple repositories with their own tags
 (each list entry may be a string or specify additional tags):
@@ -986,9 +999,16 @@ cause port mapping conflicts.
 Image Security Scans
 ====================
 
-Pushed docker images may be automatically scanned for vulnerabilities using the ``security-scan``
-global configuration options or the ``--security-scan-*`` command line options that may override
-the global configuration.  Just set ``security-scan.enabled`` to true to enable automatic scans.
+Pushed docker images may be automatically scanned for vulnerabilities using (in priority order):
+
+* The ``security-scan`` configuration on ``push`` step attributes
+* The ``--security-scan-*`` command line options
+* The ``security-scan`` global configuration options
+
+Just set ``security-scan.enabled`` to true to enable automatic scans. The config specified on the
+command line options overrides the global config completely, but configuration on the push step
+attribute is merged with the command line/global config. Additionally note that the ``cache-dir``
+can only be configured on the global/command line level.
 
 The ``max-score-threshold`` may also be configured to fail the build if the max score of the
 detected vulnerabilities is greater than or equal to the ``max-score-threshold`` value. This

--- a/buildrunner/config/models_step.py
+++ b/buildrunner/config/models_step.py
@@ -28,6 +28,14 @@ def _validate_artifact_type(value) -> Any:
 AnnotatedArtifact = Annotated[Any, BeforeValidator(_validate_artifact_type)]
 
 
+class StepPushSecurityScanConfig(BaseModel, extra="forbid"):
+    enabled: Optional[bool] = None
+    scanner: Optional[str] = None
+    version: Optional[str] = None
+    config: Optional[dict] = None
+    max_score_threshold: Optional[float] = Field(None, alias="max-score-threshold")
+
+
 class StepTask(BaseModel, extra="forbid"):
     """
     Used for type checking.
@@ -173,6 +181,9 @@ class StepPushCommit(StepTask):
         min_length=1,
     )
     push: bool
+    security_scan: Optional[StepPushSecurityScanConfig] = Field(
+        None, alias="security-scan"
+    )
 
 
 class Step(BaseModel, extra="forbid"):

--- a/buildrunner/steprunner/tasks/push.py
+++ b/buildrunner/steprunner/tasks/push.py
@@ -116,9 +116,11 @@ class PushBuildStepRunnerTask(BuildStepRunnerTask):
         return {ARTIFACT_SECURITY_SCAN_KEY: scan_results}
 
     def _security_scan_single(
-        self, repo: str, push_security_scan: Optional[StepPushSecurityScanConfig]
+        self,
+        repo: str,
+        tag: str,
+        push_security_scan: Optional[StepPushSecurityScanConfig],
     ) -> Dict[str, dict]:
-        tag = BuildRunnerConfig.get_instance().default_tag
         log_image_ref = f"{repo}:{tag}"
         result = self._security_scan(
             repository=repo,
@@ -427,7 +429,7 @@ class PushBuildStepRunnerTask(BuildStepRunnerTask):
                             "docker:repository": repo.repository,
                             "docker:tags": repo.tags,
                             **self._security_scan_single(
-                                repo.repository, repo.security_scan
+                                repo.repository, repo.tags[-1], repo.security_scan
                             ),
                         },
                     )

--- a/docs/global-configuration.rst
+++ b/docs/global-configuration.rst
@@ -124,9 +124,9 @@ they are used when put into the global configuration file:
     # Only trivy is currently supported
     scanner: "trivy"
     # The version of the trivy image to pull
-    version: str = "latest"
+    version: "latest"
     # The local cache directory for the scanner (used if supported by the scanner)
-    cache_dir: null
+    cache-dir: null
     config:
       # Timeout after 20 minutes by default
       timeout: 20m

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = "3.6"
+BASE_VERSION = "3.7"
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BUILDRUNNER_DIR = os.path.join(SOURCE_DIR, "buildrunner")

--- a/tests/test-files/test-security-scan.yaml
+++ b/tests/test-files/test-security-scan.yaml
@@ -15,14 +15,14 @@ steps:
       - linux/arm64
     push: adobe/buildrunner-test-security-scan2
 
-#  test-without-build-tag:
-#    build:
-#      dockerfile: |
-#        FROM {{ DOCKER_REGISTRY }}/busybox:latest
-#    push:
-#      repository: adobe/buildrunner-test-security-scan3
-#      tags: [latest]
-#      add_build_tag: false
+  test-without-build-tag:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+    push:
+      repository: adobe/buildrunner-test-security-scan3
+      tags: [latest]
+      add_build_tag: false
 
   test-commit-does-not-scan:
     build:

--- a/tests/test-files/test-security-scan.yaml
+++ b/tests/test-files/test-security-scan.yaml
@@ -1,0 +1,56 @@
+steps:
+
+  test-single:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+    push: adobe/buildrunner-test-security-scan1
+
+  test-multiplatform:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+      platforms:
+      - linux/amd64
+      - linux/arm64
+    push: adobe/buildrunner-test-security-scan2
+
+#  test-without-build-tag:
+#    build:
+#      dockerfile: |
+#        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+#    push:
+#      repository: adobe/buildrunner-test-security-scan3
+#      tags: [latest]
+#      add_build_tag: false
+
+  test-commit-does-not-scan:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+    commit:
+      repository: adobe/buildrunner-test-security-scan4
+      security-scan:
+        # Set the threshold very low, but this will not fail since a commit does not scan images
+        max-score-threshold: 0.1
+
+  test-override-scan-config:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+    push:
+      repository: adobe/buildrunner-test-security-scan5
+      security-scan:
+        # Set the threshold very low but also disable scanning
+        enabled: False
+        max-score-threshold: 0.1
+
+  test-override-scan-config2:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+    push:
+      repository: adobe/buildrunner-test-security-scan6
+      security-scan:
+        # Set the threshold above what is possible to make sure it scans correctly
+        max-score-threshold: 15.0

--- a/tests/test-files/test-xfail-security-scan.yaml
+++ b/tests/test-files/test-xfail-security-scan.yaml
@@ -1,0 +1,16 @@
+steps:
+
+  test-fail-with-low-threshold:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/busybox:latest
+    push:
+      repository: adobe/buildrunner-test-security-scan
+      security-scan:
+        enabled: True
+        max-score-threshold: -0.1
+        config:
+          security-checks:
+          - vuln
+          severity:
+          - LOW

--- a/tests/test_buildrunner_files.py
+++ b/tests/test_buildrunner_files.py
@@ -28,11 +28,18 @@ def _get_test_args(file_name: str) -> Optional[List[str]]:
         # Override platform to amd and use local images
         return ["--local-images", "--platform", "linux/amd64"]
 
+    if file_name == "test-security-scan.yaml":
+        # Override to enable security scanning
+        return ["--security-scan-enabled", "true"]
+
     # No additional args for this test file
     return None
 
 
 def _get_exit_code(file_name: str) -> int:
+    if file_name.startswith("test-xfail-security-scan"):
+        return 1
+
     if file_name.startswith("test-xfail"):
         return os.EX_CONFIG
 

--- a/tests/test_config_validation/test_models.py
+++ b/tests/test_config_validation/test_models.py
@@ -1,0 +1,92 @@
+import pytest
+
+from buildrunner.config import models
+from buildrunner.config import models_step
+
+
+@pytest.mark.parametrize(
+    "global_config, step_config, merged_config",
+    [
+        # Override nothing (no step config)
+        (
+            {},
+            None,
+            {
+                "enabled": False,
+                "scanner": "trivy",
+                "version": "latest",
+                "cache-dir": None,
+                "config": {
+                    "timeout": "20m",
+                    "exit-code": 0,
+                },
+                "max-score-threshold": None,
+            },
+        ),
+        # Override enabled only
+        (
+            {},
+            {"enabled": True},
+            {
+                "enabled": True,
+                "scanner": "trivy",
+                "version": "latest",
+                "cache-dir": None,
+                "config": {
+                    "timeout": "20m",
+                    "exit-code": 0,
+                },
+                "max-score-threshold": None,
+            },
+        ),
+        # Override everything
+        (
+            {
+                "enabled": True,
+                "scanner": "global-scanner",
+                "version": "global-version",
+                "cache-dir": "global-cache",
+                "max-score-threshold": 1.1,
+            },
+            {
+                "enabled": False,
+                "scanner": "step-scanner",
+                "version": "step-version",
+                "config": {
+                    "exit-code": 1,
+                    "step-config": True,
+                },
+                "max-score-threshold": 2.1,
+            },
+            {
+                "enabled": False,
+                "scanner": "step-scanner",
+                "version": "step-version",
+                "cache-dir": "global-cache",
+                "config": {
+                    "timeout": "20m",
+                    "exit-code": 1,
+                    "step-config": True,
+                },
+                "max-score-threshold": 2.1,
+            },
+        ),
+    ],
+)
+def test_security_scan_config_merge(global_config, step_config, merged_config):
+    global_security_scan_config = models.GlobalSecurityScanConfig(**global_config)
+    step_security_scan_config = (
+        models_step.StepPushSecurityScanConfig(**step_config) if step_config else None
+    )
+
+    merged_security_scan_config = global_security_scan_config.merge_scan_config(
+        step_security_scan_config
+    )
+    assert merged_security_scan_config == models.GlobalSecurityScanConfig(
+        **merged_config
+    )
+
+    # Make sure the original object was unchanged
+    assert (
+        models.GlobalSecurityScanConfig(**global_config) == global_security_scan_config
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
Adds security scan overrides at the step level and fixes an issue when add_build_tag is false.

### What issues does this PR fix or reference?
When add_build_tag is false, the default tag doesn't exist and the security scan breaks.

### Previous Behavior
Broken security scan

### New Behavior
Working security scan

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

