### PR TITLE
Add cache_from and cache_to support for multiplatform builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,20 +268,22 @@ shows the different configuration options available:
         #     a directory on the client `cache_from="type=local,src=path/to/dir"`.
         #     It's also possible to use a dict or list of dict form for this
         #     argument. e.g.
-        #     `cache_from=dict(type="local", src="path/to/dir")`
+        #     `cache_from={type="local", src="path/to/dir"}`
         # cache_to: Works only with the container driver. Sends the resulting
         #     docker cache either to a registry `cache_to="user/app:cache"`,
         #     or to a local directory `cache_to="type=local,dest=path/to/dir"`.
         #     It's also possible to use a dict form for this argument. e.g.
-        #     `cache_to=dict(type="local", dest="path/to/dir", mode="max")`
-        cache_from:
-          my-images/image:PR-123
+        #     `cache_to={type="local", dest="path/to/dir", mode="max"}`
+        cache_from: my-images/image:PR-123
         <or>
         cache_from:
-          - {"type": "local", "src": "path/to/dir"}
+          - type: local
+            src: path/to/dir
 
         cache_to:
-          {"type": "local", "dest": "my-images/image:PR-123", "mode": "max"}
+          type: local
+          dest: path/to/dir
+          mode: max
 
 
         # Whether to do a docker pull of the "FROM" image prior to the build.

--- a/README.rst
+++ b/README.rst
@@ -250,15 +250,39 @@ shows the different configuration options available:
         # images but may not be desired when building images for publishing
         no-cache: true/false (defaults to false)
 
+        # The following applies to single platform builds.
         # Specify Docker images to consider as cache sources,
         # similar to the --cache-from option used by Docker.
         # Buildrunner will attempt to pull these images from the remote registry.
         # If the pull is unsuccessful, buildrunner will still pass in the image name
         # into --cache-from, allowing a cache check in the host machine cache
-        # NOTE: Does not work for multiplatform builds
         cache_from:
           - my-images/image:PR-123
           - my-images/image:latest
+
+        # The following applies to multiplatform builds.
+        # Specify Docker images to consider as cache sources,
+        # similar to the --cache-from option used by Docker.
+        # cache_from: Works only with the container driver. Loads the cache
+        #     (if needed) from a registry `cache_from="user/app:cache"`  or
+        #     a directory on the client `cache_from="type=local,src=path/to/dir"`.
+        #     It's also possible to use a dict or list of dict form for this
+        #     argument. e.g.
+        #     `cache_from=dict(type="local", src="path/to/dir")`
+        # cache_to: Works only with the container driver. Sends the resulting
+        #     docker cache either to a registry `cache_to="user/app:cache"`,
+        #     or to a local directory `cache_to="type=local,dest=path/to/dir"`.
+        #     It's also possible to use a dict form for this argument. e.g.
+        #     `cache_to=dict(type="local", dest="path/to/dir", mode="max")`
+        cache_from:
+          my-images/image:PR-123
+        <or>
+        cache_from:
+          - {"type": "local", "src": "path/to/dir"}
+
+        cache_to:
+          {"type": "local", "dest": "my-images/image:PR-123", "mode": "max"}
+
 
         # Whether to do a docker pull of the "FROM" image prior to the build.
         # This is critical if you are building from images that are changing

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -366,10 +366,10 @@ class BuildRunner:
                     step_config,
                 ) in buildrunner_config.run_config.steps.items():
                     # Reset the cache_from and cache_to for each step to the global values
-                    multi_platform._cache_from = (
+                    multi_platform.set_cache_from(
                         buildrunner_config.global_config.docker_build_cache.from_config
                     )
-                    multi_platform._cache_to = (
+                    multi_platform.set_cache_to(
                         buildrunner_config.global_config.docker_build_cache.to_config
                     )
 
@@ -383,12 +383,12 @@ class BuildRunner:
                             LOGGER.info(
                                 f"Overriding cache_from with {step_config.build.cache_from}"
                             )
-                            multi_platform._cache_from = step_config.build.cache_from
+                            multi_platform.set_cache_from(step_config.build.cache_from)
                         if step_config.build and step_config.build.cache_to:
                             LOGGER.info(
                                 f"Overriding cache_to with {step_config.build.cache_to}"
                             )
-                            multi_platform._cache_to = step_config.build.cache_to
+                            multi_platform.set_cache_to(step_config.build.cache_to)
 
                         build_step_runner = BuildStepRunner(
                             self, step_name, step_config, image_config, multi_platform

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -365,10 +365,31 @@ class BuildRunner:
                     step_name,
                     step_config,
                 ) in buildrunner_config.run_config.steps.items():
+                    # Reset the cache_from and cache_to for each step to the global values
+                    multi_platform._cache_from = (
+                        buildrunner_config.global_config.docker_build_cache.from_config
+                    )
+                    multi_platform._cache_to = (
+                        buildrunner_config.global_config.docker_build_cache.to_config
+                    )
+
                     if not self.steps_to_run or step_name in self.steps_to_run:
                         image_config = BuildStepRunner.ImageConfig(
                             self.local_images, self.platform
                         )
+
+                        # Override the multiplatform cache_from and cache_to if the step has its own
+                        if step_config.build and step_config.build.cache_from:
+                            LOGGER.info(
+                                f"Overriding cache_from with {step_config.build.cache_from}"
+                            )
+                            multi_platform._cache_from = step_config.build.cache_from
+                        if step_config.build and step_config.build.cache_to:
+                            LOGGER.info(
+                                f"Overriding cache_to with {step_config.build.cache_to}"
+                            )
+                            multi_platform._cache_to = step_config.build.cache_to
+
                         build_step_runner = BuildStepRunner(
                             self, step_name, step_config, image_config, multi_platform
                         )

--- a/buildrunner/config/models_step.py
+++ b/buildrunner/config/models_step.py
@@ -73,7 +73,10 @@ class StepBuild(StepTask):
     inject: Optional[Dict[str, Optional[str]]] = None
     no_cache: Optional[bool] = Field(alias="no-cache", default=None)
     buildargs: Optional[Dict[str, Any]] = None
-    cache_from: Optional[List[str]] = None
+    cache_from: Optional[
+        Union[str, Dict[str, str], List[Dict[str, str]], List[str]]
+    ] = None
+    cache_to: Optional[Union[str, Dict[str, str]]] = None
     # import is a python reserved keyword so we need to alias it
     import_param: Optional[str] = Field(alias="import", default=None)
 

--- a/buildrunner/config/validation.py
+++ b/buildrunner/config/validation.py
@@ -16,9 +16,7 @@ from .models_step import Step, StepPushCommit
 
 RETAG_ERROR_MESSAGE = "Multi-platform build steps cannot re-tag images. The following images are re-tagged:"
 RUN_MP_ERROR_MESSAGE = "run is not allowed in the same step as a multi-platform build"
-BUILD_MP_CACHE_ERROR_MESSAGE = (
-    "cache_from must be a dict or list(dict) in the multi-platform build step"
-)
+BUILD_MP_CACHE_ERROR_MESSAGE = "The cache_from arg must be a str, dict or list(dict) in the multi-platform build step"
 
 
 class StepImagesInfo:
@@ -262,7 +260,7 @@ def validate_multiplatform_build(
                 and all(isinstance(x, str) for x in step.build.cache_from)
             ):
                 raise ValueError(
-                    f"{BUILD_MP_CACHE_ERROR_MESSAGE} {step_name} cannot be a list(str) for multiplatform images {type(step.build.cache_from)}]"
+                    f"{BUILD_MP_CACHE_ERROR_MESSAGE} {step_name} cannot be a list(str) for multiplatform images."
                 )
 
             if step.build.import_param:

--- a/buildrunner/config/validation.py
+++ b/buildrunner/config/validation.py
@@ -16,6 +16,9 @@ from .models_step import Step, StepPushCommit
 
 RETAG_ERROR_MESSAGE = "Multi-platform build steps cannot re-tag images. The following images are re-tagged:"
 RUN_MP_ERROR_MESSAGE = "run is not allowed in the same step as a multi-platform build"
+BUILD_MP_CACHE_ERROR_MESSAGE = (
+    "cache_from must be a dict or list(dict) in the multi-platform build step"
+)
 
 
 class StepImagesInfo:
@@ -253,9 +256,13 @@ def validate_multiplatform_build(
             if not isinstance(step.build.platforms, list):
                 raise ValueError(f"platforms must be a list in build step {step_name}")
 
-            if step.build.cache_from:
+            if (
+                step.build.platforms
+                and isinstance(step.build.cache_from, list)
+                and all(isinstance(x, str) for x in step.build.cache_from)
+            ):
                 raise ValueError(
-                    f"cache_from is not allowed in multi-platform build step {step_name}"
+                    f"{BUILD_MP_CACHE_ERROR_MESSAGE} {step_name} cannot be a list(str) for multiplatform images {type(step.build.cache_from)}]"
                 )
 
             if step.build.import_param:

--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -105,6 +105,12 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
         if self._local_registry_is_running:
             self._stop_local_registry()
 
+    def set_cache_from(self, cache_from):
+        self._cache_from = cache_from
+
+    def set_cache_to(self, cache_to):
+        self._cache_to = cache_to
+
     def _build_registry_address(self) -> str:
         """Returns the address of the local registry"""
         if self._build_registry == MP_LOCAL_REGISTRY:

--- a/buildrunner/steprunner/tasks/build.py
+++ b/buildrunner/steprunner/tasks/build.py
@@ -54,21 +54,25 @@ class BuildBuildStepRunnerTask(BuildStepRunnerTask):  # pylint: disable=too-many
 
         buildrunner_config = BuildRunnerConfig.get_instance()
 
-        if self.cache_from:
+        #  Pull the cache_from images only for single platform builds
+        if self.cache_from and isinstance(self.cache_from, list) and not self.platforms:
             for cache_from_image in self.cache_from:
-                try:
-                    self._docker_client.pull(cache_from_image, platform=self.platform)
-                    # If the pull is successful, add the image to be cleaned up at the end of the script
-                    self.step_runner.build_runner.generated_images.append(
-                        cache_from_image
-                    )
-                    self.step_runner.log.write(
-                        f"Using cache_from image: {cache_from_image}\n"
-                    )
-                except Exception:  # pylint: disable=broad-except
-                    self.step_runner.log.write(
-                        f"WARNING: Unable to pull the cache_from image: {cache_from_image}\n"
-                    )
+                if isinstance(cache_from_image, str):
+                    try:
+                        self._docker_client.pull(
+                            cache_from_image, platform=self.platform
+                        )
+                        # If the pull is successful, add the image to be cleaned up at the end of the script
+                        self.step_runner.build_runner.generated_images.append(
+                            cache_from_image
+                        )
+                        self.step_runner.log.write(
+                            f"Using cache_from image: {cache_from_image}\n"
+                        )
+                    except Exception:  # pylint: disable=broad-except
+                        self.step_runner.log.write(
+                            f"WARNING: Unable to pull the cache_from image: {cache_from_image}\n"
+                        )
 
         for src_glob, dest_path in (step.inject or {}).items():
             if not dest_path:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = "3.7"
+BASE_VERSION = "3.8"
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BUILDRUNNER_DIR = os.path.join(SOURCE_DIR, "buildrunner")

--- a/tests/test-files/test-general.yaml
+++ b/tests/test-files/test-general.yaml
@@ -45,7 +45,7 @@ steps:
     run:
       services:
         rabbitmq:
-          image: {{ DOCKER_REGISTRY }}/rabbitmq:3.4
+          image: {{ DOCKER_REGISTRY }}/rabbitmq:3.13
           hostname: rabbitmq
           env:
             RABBITMQ_NODENAME: test-rabbitmq

--- a/tests/test_config_validation/test_multi_platform.py
+++ b/tests/test_config_validation/test_multi_platform.py
@@ -1,9 +1,6 @@
 import pytest
 
-from buildrunner.config.validation import (
-    BUILD_MP_CACHE_ERROR_MESSAGE,
-    RUN_MP_ERROR_MESSAGE,
-)
+from buildrunner.config.validation import RUN_MP_ERROR_MESSAGE
 
 
 @pytest.mark.parametrize(
@@ -87,23 +84,7 @@ from buildrunner.config.validation import (
                         platforms:
                             - linux/amd64
                             - linux/arm64/v8
-                        cache_from:
-                            - busybox:latest
-            """,
-            [BUILD_MP_CACHE_ERROR_MESSAGE],
-        ),
-        (
-            """
-            steps:
-                build-container-multi-platform:
-                    build:
-                        dockerfile: |
-                            FROM busybox:latest
-                        platforms:
-                            - linux/amd64
-                            - linux/arm64/v8
-                        cache_from:
-                            - { type: local, src: busybox:latest }
+                        cache_from: busybox:latest
             """,
             [],
         ),
@@ -118,7 +99,24 @@ from buildrunner.config.validation import (
                             - linux/amd64
                             - linux/arm64/v8
                         cache_from:
-                            { type: local, src: busybox:latest }
+                            - type: local
+                              src: path/to/dir
+            """,
+            [],
+        ),
+        (
+            """
+            steps:
+                build-container-multi-platform:
+                    build:
+                        dockerfile: |
+                            FROM busybox:latest
+                        platforms:
+                            - linux/amd64
+                            - linux/arm64/v8
+                        cache_from:
+                            type: local
+                            src: path/to/dir
             """,
             [],
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add cache_from and cache_to support for multiplatform builds. Passes cache_from and cache_to arguments to python_on_whales.

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
Improve multiplatform support.

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

