### PR TITLE
Upgrading pyyaml to 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ pynacl==1.5.0
     # via paramiko
 python-on-whales==0.70.1
     # via -r requirements.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via -r requirements.in
 readme-renderer==37.3
     # via twine


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
When I was trying to install buildrunner I was getting errors about being unable to install wheel on pyyaml I think that this is because pyyaml 6.0 [isn't available for python 3.12](https://www.piwheels.org/project/pyyaml/)
Updating it to 6.0.1 made it so that I could install and I've been able to successfully build as well.

### What issues does this PR fix or reference?
Being able to install buildrunner

### Previous Behavior
Collecting pyyaml==6.0 (from buildrunner)
  Using cached PyYAML-6.0.tar.gz (124 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [54 lines of output]
 

### New Behavior
success

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [-] I have added tests to cover my changes.
- [-] I have updated the base version in ``setup.py`` (if appropriate).

