### PR TITLE
Add rename artifact functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -577,6 +577,9 @@ the run step:
         # ignored.  If the directory tree should be gathered verbatim without
         # archiving then the property ``format:uncompressed`` can be used.
         #
+        # Rename allows for specifying exact matches to rename for files and
+        # compressed directories. Wildcard (*) matches is not supported.
+        #
         # NOTE: Artifacts can only be archived from the /source directory using
         # a relative path or a full path. Files outside of this directory will
         # fail to be archived.
@@ -586,6 +589,7 @@ the run step:
             [type: tar|zip]
             [compression: gz|bz2|xz|lzma|lzip|lzop|z]
             [push: true|false]
+            [rename: new-name]
             property1: value1
             property2: value2
 
@@ -824,6 +828,20 @@ container:
       run:
         artifacts:
           build/artifacts/*.x86_64.rpm:
+
+This example shows renaming artifacts which would otherwise have the same name:
+
+.. code:: yaml
+
+  steps:
+    package:
+      build: package-container
+      run:
+        artifacts:
+          build/artifacts/variation1/package-container.x86_64.rpm:
+            rename: package-container1.x86_64.rpm
+          build/artifacts/variation2/package-container.x86_64.rpm:
+            rename: package-container2.x86_64.rpm
 
 This example uses one step to create a package and another to run an
 integration test:

--- a/buildrunner/config/models_step.py
+++ b/buildrunner/config/models_step.py
@@ -59,6 +59,7 @@ class Artifact(BaseModel):
     type: Optional[Any] = None
     compression: Optional[str] = None
     push: Optional[bool] = None
+    rename: Optional[str] = None
 
 
 class StepBuild(StepTask):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = "3.8"
+BASE_VERSION = "3.9"
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BUILDRUNNER_DIR = os.path.join(SOURCE_DIR, "buildrunner")

--- a/tests/test-files/test-push-artifact.yaml
+++ b/tests/test-files/test-push-artifact.yaml
@@ -55,3 +55,45 @@ steps:
       artifacts:
         'test-push-false-dir': {format: 'uncompressed', prop1: 'hello', push: False}
         'test-push-false.txt': {format: 'file', push: False}
+
+  single-file-rename:
+    run:
+      image: ubuntu:20.10
+      cmds:
+        - mkdir -p dir1/dir2
+        - echo "single-file-artifacts - Hello, world!!" > hello.txt
+        - echo "single-file-artifacts - Hello, world! 1/" > dir1/hello.txt
+        - echo "single-file-artifacts - Hello, world!! 1/2/" > dir1/dir2/hello.txt
+      artifacts:
+        hello.txt:
+          rename: hello-world.txt
+        dir1/hello.txt:
+          format: uncompressed
+          rename: hello-world1.txt
+        dir1/dir2/hello.txt:
+          format: uncompressed
+          rename: hello-world2.txt
+
+  archive-file-rename:
+    run:
+      image: ubuntu:latest
+      cmds:
+        - mkdir -p dir1/dir2
+        - mkdir -p dir3/dir2
+        - mkdir -p uncompressed-dir
+        - echo "directory-archiver - Hello, world!!" > hello.txt
+        - echo "directory-archiver - Hello, world! 1" > dir1/hello.txt
+        - echo "directory-archiver - Hello, world! 2" > dir1/hello1.txt
+        - echo "directory-archiver - Hello, world! 3" > dir1/hello2.txt
+        - echo "directory-archiver - Hello, world!! 1/2/" > dir1/dir2/hello.txt
+        - echo "directory-archiver - Hello, world! 3-2" > dir3/dir2/hello1.txt
+        - echo "directory-archiver - Hello, world! 3-2" > dir3/dir2/hello2.txt
+      artifacts:
+        dir1:
+          compression: tar
+        dir1/dir2:
+          compression: tar
+          rename: dir1-dir2
+        dir3/dir2:
+          compression: tar
+          rename: dir3-dir2

--- a/tests/test_config_validation/test_validation_artifacts.py
+++ b/tests/test_config_validation/test_validation_artifacts.py
@@ -6,130 +6,142 @@ import pytest
     [
         (
             """
-    steps:
-      build-remote:
-        remote:
-          host: myserver.ut1
-          cmd: docker build -t mytest-reg/buildrunner-test .
-          artifacts:
-            bogus/path/to/artifacts/*:
-              type: tar
-              compression: lzma
-    """,
+            steps:
+              build-remote:
+                remote:
+                  host: myserver.ut1
+                  cmd: docker build -t mytest-reg/buildrunner-test .
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      type: tar
+                      compression: lzma
+            """,
             [],
         ),
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*:
-              type: zip
-              compression: lzma
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      type: zip
+                      compression: lzma
+            """,
             [],
         ),
         # Valid compression
         (
             """
-    steps:
-      build-remote:
-        remote:
-          host: myserver.ut1
-          cmd: docker build -t mytest-reg/buildrunner-test .
-          artifacts:
-            bogus/path/to/artifacts/*:
-              type: tar
-              compression: gz
-    """,
+            steps:
+              build-remote:
+                remote:
+                  host: myserver.ut1
+                  cmd: docker build -t mytest-reg/buildrunner-test .
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      type: tar
+                      compression: gz
+            """,
             [],
         ),
         # Valid run format
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*:
-              format: uncompressed
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      format: uncompressed
+            """,
             [],
         ),
         #  Checks zip type
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*:
-              type: zip
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      type: zip
+            """,
             [],
         ),
         # Checks tar type
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*:
-              type: tar
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      type: tar
+            """,
             [],
         ),
         #  Push must be a boolean
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*:
-              push: bogus
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      push: bogus
+            """,
             ["Input should be a valid boolean"],
         ),
         # Artifact may be a blank string
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*: ''
-            bogus/path/to/this_thing: ''
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*: ''
+                    bogus/path/to/this_thing: ''
+            """,
             [],
         ),
         # Valid push
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*:
-              push: True
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      push: True
+            """,
             [],
         ),
         # Valid extra properties
         (
             """
-    steps:
-      build-run:
-        run:
-          artifacts:
-            bogus/path/to/artifacts/*:
-              push: True
-              something_else: awesome data
-              something_else2: True
-              something_else3: 123
-    """,
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/*:
+                      push: True
+                      something_else: awesome data
+                      something_else2: True
+                      something_else3: 123
+            """,
+            [],
+        ),
+        # Rename
+        (
+            """
+            steps:
+              build-run:
+                run:
+                  artifacts:
+                    bogus/path/to/artifacts/my-artifact.txt:
+                      rename: my-artifact-renamed.txt
+            """,
             [],
         ),
     ],

--- a/tests/test_push_artifact.py
+++ b/tests/test_push_artifact.py
@@ -121,3 +121,35 @@ def test_push_false():
         0,
         artifacts_in_file,
     )
+
+
+def test_file_remame():
+    artifacts_in_file = {
+        "single-file-rename/hello-world.txt": True,
+        "single-file-rename/hello-world1.txt": True,
+        "single-file-rename/hello-world2.txt": True,
+        "single-file-rename/hello.txt": False,
+    }
+    _test_buildrunner_file(
+        f"{TEST_DIR}/test-files",
+        "test-push-artifact.yaml",
+        ["-s", "single-file-rename"],
+        0,
+        artifacts_in_file,
+    )
+
+
+def test_archive_file_remame():
+    artifacts_in_file = {
+        "archive-file-rename/dir1.tar.gz": True,
+        "archive-file-rename/dir1-dir2.tar.gz": True,
+        "archive-file-rename/dir3-dir2.tar.gz": True,
+        "archive-file-rename/dir2.tar.gz": False,
+    }
+    _test_buildrunner_file(
+        f"{TEST_DIR}/test-files",
+        "test-push-artifact.yaml",
+        ["-s", "archive-file-rename"],
+        0,
+        artifacts_in_file,
+    )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add ability to rename artifacts which match artifacts exactly. Renaming of wildcard matches of artifacts is not supported in this PR.

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
There are situations where artifacts with the same base name overwrite each other in the artifacts output directory.

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

