### PR TITLE
Fix issue with logging in docker image

### DIFF
--- a/buildrunner/docker/runner.py
+++ b/buildrunner/docker/runner.py
@@ -380,8 +380,8 @@ class DockerRunner:
                 self.shell = "/bin/sh"
                 exit_code = self.run(f"mkdir -p {docker_path}")
                 if exit_code:
-                    logger.write(
-                        f"WARNING: There was an issue creating {docker_path} on the docker container\n"
+                    logger.warning(
+                        f"There was an issue creating {docker_path} on the docker container"
                     )
 
                 # Allow multiple people to read from the file at the same time
@@ -390,15 +390,15 @@ class DockerRunner:
                 file_obj = acquire_flock_open_read_binary(
                     lock_file=actual_cache_archive_file, logger=logger
                 )
-                logger.write(
+                logger.info(
                     "File lock acquired. Attempting to put cache into the container."
                 )
 
                 restored_cache_src.add(docker_path)
                 if not self._put_cache_in_container(docker_path, file_obj):
-                    logger.write(
-                        f"WARNING: An error occurred when trying to use cache "
-                        f"{actual_cache_archive_file} at the path {docker_path}\n"
+                    logger.warning(
+                        f"An error occurred when trying to use cache "
+                        f"{actual_cache_archive_file} at the path {docker_path}"
                     )
 
             except docker.errors.APIError:
@@ -406,7 +406,7 @@ class DockerRunner:
             finally:
                 self.shell = orig_shell
                 release_flock(file_obj, logger)
-                logger.write("Cache was put into the container. Released file lock.")
+                logger.info("Cache was put into the container. Released file lock.")
 
     @retry(exceptions=BuildRunnerCacheTimeout, tries=CACHE_NUM_RETRIES)
     @timeout_decorator.timeout(

--- a/buildrunner/loggers.py
+++ b/buildrunner/loggers.py
@@ -17,6 +17,7 @@ from rich import progress
 
 
 CONSOLE_LOGGER_NAME = "buildrunner"
+ENCODING = sys.stdout.encoding if sys.stdout.encoding else "utf8"
 
 
 class CustomColoredFormatter(colorlog.ColoredFormatter):
@@ -97,7 +98,7 @@ class ConsoleLogger:
         with color.
         """
         if not isinstance(output, str):
-            output = str(output, encoding=sys.stdout.encoding, errors="replace")
+            output = str(output, encoding=ENCODING, errors="replace")
         if output and output[-1] == "\n":
             output = output[:-1]
         for line in output.split("\n"):
@@ -176,7 +177,7 @@ class ContainerLogger(ConsoleLogger):
         """
         # Ensure that the output is a string
         if not isinstance(output, str):
-            output = str(output, encoding=sys.stdout.encoding, errors="replace")
+            output = str(output, ENCODING, errors="replace")
 
         for char in output:
             self._buffer.append(char)

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 from buildrunner import BuildRunner
 from buildrunner.docker.runner import DockerRunner
-from buildrunner.loggers import ConsoleLogger, ContainerLogger
+from buildrunner.loggers import ConsoleLogger
 import pytest
 
 
@@ -64,8 +64,11 @@ def fixture_setup_tmp_dir_context():
 
 @pytest.fixture(name="mock_logger")
 def fixture_mock_logger():
-    mock_logger = mock.create_autospec(ContainerLogger)
-    mock_logger.write.side_effect = lambda message: print(message.strip())
+    mock_logger = mock.MagicMock()
+    mock_logger.info.side_effect = lambda message: print(f"[info] {message.strip()}")
+    mock_logger.warning.side_effect = lambda message: print(
+        f"[warning] {message.strip()}"
+    )
     return mock_logger
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
Fixes this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.11/site-packages/buildrunner-3.8.999-py3.11.egg/buildrunner/steprunner/tasks/run.py", line 609, in attach_to_service
    service_runner.attach_until_finished(service_logger)
  File "/usr/local/lib/python3.11/site-packages/buildrunner-3.8.999-py3.11.egg/buildrunner/docker/runner.py", line 630, in attach_until_finished
    stream.write(line)
  File "/usr/local/lib/python3.11/site-packages/buildrunner-3.8.999-py3.11.egg/buildrunner/loggers.py", line 179, in write
    output = str(output, encoding=sys.stdout.encoding, errors="replace")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: str() argument 'encoding' must be str, not None
```

### Previous Behavior
Failure

### New Behavior
Success

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [ ] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

