### PR TITLE
Add support for post-build with buildx builder

### DIFF
--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -217,11 +217,19 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
         ) as tmp_dir:
             context_dir = os.path.join(tmp_dir, f"{dir_prefix}/")
             shutil.copytree(
-                path, context_dir, ignore=shutil.ignore_patterns(dir_prefix, ".git")
+                path,
+                context_dir,
+                ignore=shutil.ignore_patterns(dir_prefix, ".git"),
+                symlinks=True,
             )
 
             for src, dest in inject.items():
                 src_path = os.path.join(path, src)
+
+                # Remove '/' prefix
+                if dest.startswith("/"):
+                    dest = dest[1:]
+
                 dest_path = os.path.join(context_dir, dest)
 
                 # Check to see if the dest dir exists, if not create it
@@ -229,6 +237,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
                 if not os.path.isdir(dest_dir):
                     os.mkdir(dest_dir)
 
+                # Copy source to destination
                 if os.path.isdir(src_path):
                     shutil.copytree(src_path, dest_path)
                 else:

--- a/tests/test-files/test-general-buildx.yaml
+++ b/tests/test-files/test-general-buildx.yaml
@@ -1,6 +1,5 @@
-use-legacy-builder: true
+use-legacy-builder: false
 steps:
-
   test:
     build:
       no-cache: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add buildx support for post-build. 

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
Buildx requires a named images and not just SHA digests of the image in the dockerfile. This adds a tag the run image before the post-build and then removes it.

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [ ] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [ ] I have updated the base version in ``setup.py`` (if appropriate).

