### PR TITLE
Add buildx builder support to get_source_image method

### DIFF
--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -243,6 +243,13 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
                 else:
                     shutil.copy(src_path, dest_path)
 
+            # Dockerfile listed in inject will overwrite the dockerfile passed in
+            if dockerfile and "Dockerfile" not in inject.values():
+                LOGGER.info(
+                    f"Injecting Dockerfile {dockerfile} to context directory '{context_dir}'"
+                )
+                shutil.copy(dockerfile, f"{context_dir}/Dockerfile")
+
             assert os.path.isdir(
                 context_dir
             ), f"Failed to create context dir {context_dir}"
@@ -252,7 +259,6 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
                 tags=[image_ref],
                 platforms=[platform],
                 load=True,
-                file=dockerfile,
                 target=target,
                 builder=builder,
                 build_args=build_args,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = "3.11"
+BASE_VERSION = "3.12"
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BUILDRUNNER_DIR = os.path.join(SOURCE_DIR, "buildrunner")

--- a/tests/test-files/test-push-artifact-buildx.yaml
+++ b/tests/test-files/test-push-artifact-buildx.yaml
@@ -1,3 +1,4 @@
+use-legacy-builder: false
 steps:
 
   test-no-artifacts:

--- a/tests/test-files/test-push-artifact-legacy.yaml
+++ b/tests/test-files/test-push-artifact-legacy.yaml
@@ -1,0 +1,100 @@
+use-legacy-builder: true
+steps:
+
+  test-no-artifacts:
+    run:
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
+      cmds: [
+        'echo "hello"'
+      ]
+
+  test-no-artifact-properties:
+    run:
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
+      cmds: [
+        'mkdir test-no-artifact-properties-dir',
+        'echo "hello" > test-no-artifact-properties-dir/test1.txt',
+        'echo "hello" > test-no-artifact-properties-dir/test2.txt',
+        'echo "hello" > test-no-artifact-properties.txt',
+      ]
+
+  test-no-push-properties:
+    run:
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
+      cmds: [
+        'mkdir test-no-push-properties-dir',
+        'echo "hello" > test-no-push-properties-dir/test1.txt',
+        'echo "hello" > test-no-push-properties-dir/test2.txt',
+        'echo "hello" > test-no-push-properties.txt',
+      ]
+      artifacts:
+        'test-no-push-properties-dir': {format: 'uncompressed', prop1: 'hello'}
+        'test-no-push-properties.txt': {format: 'file'}
+
+  test-push-true:
+    run:
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
+      cmds: [
+        'mkdir test-push-true-dir',
+        'echo "hello" > test-push-true-dir/test1.txt',
+        'echo "hello" > test-push-true-dir/test2.txt',
+        'echo "hello" > test-push-true.txt',
+      ]
+      artifacts:
+        'test-push-true-dir': {format: 'uncompressed', prop1: 'hello', push: True}
+        'test-push-true.txt': {format: 'file', push: True}
+
+  test-push-false:
+    run:
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
+      cmds: [
+        'mkdir test-push-false-dir',
+        'echo "hello" > test-push-false-dir/test1.txt',
+        'echo "hello" > test-push-false-dir/test2.txt',
+        'echo "hello" > test-push-false.txt',
+      ]
+      artifacts:
+        'test-push-false-dir': {format: 'uncompressed', prop1: 'hello', push: False}
+        'test-push-false.txt': {format: 'file', push: False}
+
+  single-file-rename:
+    run:
+      image: ubuntu:20.10
+      cmds:
+        - mkdir -p dir1/dir2
+        - echo "single-file-artifacts - Hello, world!!" > hello.txt
+        - echo "single-file-artifacts - Hello, world! 1/" > dir1/hello.txt
+        - echo "single-file-artifacts - Hello, world!! 1/2/" > dir1/dir2/hello.txt
+      artifacts:
+        hello.txt:
+          rename: hello-world.txt
+        dir1/hello.txt:
+          format: uncompressed
+          rename: hello-world1.txt
+        dir1/dir2/hello.txt:
+          format: uncompressed
+          rename: hello-world2.txt
+
+  archive-file-rename:
+    run:
+      image: ubuntu:latest
+      cmds:
+        - mkdir -p dir1/dir2
+        - mkdir -p dir3/dir2
+        - mkdir -p uncompressed-dir
+        - echo "directory-archiver - Hello, world!!" > hello.txt
+        - echo "directory-archiver - Hello, world! 1" > dir1/hello.txt
+        - echo "directory-archiver - Hello, world! 2" > dir1/hello1.txt
+        - echo "directory-archiver - Hello, world! 3" > dir1/hello2.txt
+        - echo "directory-archiver - Hello, world!! 1/2/" > dir1/dir2/hello.txt
+        - echo "directory-archiver - Hello, world! 3-2" > dir3/dir2/hello1.txt
+        - echo "directory-archiver - Hello, world! 3-2" > dir3/dir2/hello2.txt
+      artifacts:
+        dir1:
+          compression: tar
+        dir1/dir2:
+          compression: tar
+          rename: dir1-dir2
+        dir3/dir2:
+          compression: tar
+          rename: dir3-dir2

--- a/tests/test_push_artifact.py
+++ b/tests/test_push_artifact.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import json
+import pytest
 
 from tests import test_runner
 
@@ -52,104 +53,135 @@ def _test_buildrunner_file(
         assert len(artifacts) == 0
 
 
-def test_no_artifacts():
-    artifacts_in_file = {}
+# Test legacy builder
+@pytest.mark.parametrize(
+    "test_name, artifacts_in_file",
+    [
+        ("test-no-artifacts", {}),
+        (
+            "test-no-artifact-properties",
+            {
+                "test-no-artifact-properties/test-no-artifact-properties-dir/test1.txt": False,
+                "test-no-artifact-properties/test-no-artifacts-properties-dir/test2.txt": False,
+                "test-no-artifact-properties/test-no-artifact-properties.txt": False,
+            },
+        ),
+        (
+            "test-no-push-properties",
+            {
+                "test-no-push-properties/test-no-push-properties-dir/test1.txt": True,
+                "test-no-push-properties/test-no-push-properties-dir/test2.txt": True,
+                "test-no-push-properties/test-no-push-properties.txt": True,
+            },
+        ),
+        (
+            "test-push-true",
+            {
+                "test-push-true/test-push-true-dir/test1.txt": True,
+                "test-push-true/test-push-true-dir/test2.txt": True,
+                "test-push-true/test-push-true.txt": True,
+            },
+        ),
+        (
+            "test-push-false",
+            {
+                "test-push-false/test-push-false-dir/test1.txt": False,
+                "test-push-false/test-push-false-dir/test2.txt": False,
+                "test-push-false/test-push-false.txt": False,
+            },
+        ),
+        (
+            "single-file-rename",
+            {
+                "single-file-rename/hello-world.txt": True,
+                "single-file-rename/hello-world1.txt": True,
+                "single-file-rename/hello-world2.txt": True,
+                "single-file-rename/hello.txt": False,
+            },
+        ),
+        (
+            "archive-file-rename",
+            {
+                "archive-file-rename/dir1.tar.gz": True,
+                "archive-file-rename/dir1-dir2.tar.gz": True,
+                "archive-file-rename/dir3-dir2.tar.gz": True,
+                "archive-file-rename/dir2.tar.gz": False,
+            },
+        ),
+    ],
+)
+def test_artifacts_with_legacy_builder(test_name, artifacts_in_file):
     _test_buildrunner_file(
         f"{TEST_DIR}/test-files",
-        "test-push-artifact.yaml",
-        ["-s", "test-no-artifacts"],
+        "test-push-artifact-legacy.yaml",
+        ["-s", test_name],
         0,
         artifacts_in_file,
     )
 
 
-def test_no_artifact_properties():
-    artifacts_in_file = {
-        "test-no-artifact-properties/test-no-artifact-properties-dir/test1.txt": False,
-        "test-no-artifact-properties/test-no-artifacts-properties-dir/test2.txt": False,
-        "test-no-artifact-properties/test-no-artifact-properties.txt": False,
-    }
+# Test legacy builder
+@pytest.mark.parametrize(
+    "test_name, artifacts_in_file",
+    [
+        ("test-no-artifacts", {}),
+        (
+            "test-no-artifact-properties",
+            {
+                "test-no-artifact-properties/test-no-artifact-properties-dir/test1.txt": False,
+                "test-no-artifact-properties/test-no-artifacts-properties-dir/test2.txt": False,
+                "test-no-artifact-properties/test-no-artifact-properties.txt": False,
+            },
+        ),
+        (
+            "test-no-push-properties",
+            {
+                "test-no-push-properties/test-no-push-properties-dir/test1.txt": True,
+                "test-no-push-properties/test-no-push-properties-dir/test2.txt": True,
+                "test-no-push-properties/test-no-push-properties.txt": True,
+            },
+        ),
+        (
+            "test-push-true",
+            {
+                "test-push-true/test-push-true-dir/test1.txt": True,
+                "test-push-true/test-push-true-dir/test2.txt": True,
+                "test-push-true/test-push-true.txt": True,
+            },
+        ),
+        (
+            "test-push-false",
+            {
+                "test-push-false/test-push-false-dir/test1.txt": False,
+                "test-push-false/test-push-false-dir/test2.txt": False,
+                "test-push-false/test-push-false.txt": False,
+            },
+        ),
+        (
+            "single-file-rename",
+            {
+                "single-file-rename/hello-world.txt": True,
+                "single-file-rename/hello-world1.txt": True,
+                "single-file-rename/hello-world2.txt": True,
+                "single-file-rename/hello.txt": False,
+            },
+        ),
+        (
+            "archive-file-rename",
+            {
+                "archive-file-rename/dir1.tar.gz": True,
+                "archive-file-rename/dir1-dir2.tar.gz": True,
+                "archive-file-rename/dir3-dir2.tar.gz": True,
+                "archive-file-rename/dir2.tar.gz": False,
+            },
+        ),
+    ],
+)
+def test_artifacts_with_buildx_builder(test_name, artifacts_in_file):
     _test_buildrunner_file(
         f"{TEST_DIR}/test-files",
-        "test-push-artifact.yaml",
-        ["-s", "test-no-artifact-properties"],
-        0,
-        artifacts_in_file,
-    )
-
-
-def test_no_push_property():
-    artifacts_in_file = {
-        "test-no-push-properties/test-no-push-properties-dir/test1.txt": True,
-        "test-no-push-properties/test-no-push-properties-dir/test2.txt": True,
-        "test-no-push-properties/test-no-push-properties.txt": True,
-    }
-    _test_buildrunner_file(
-        f"{TEST_DIR}/test-files",
-        "test-push-artifact.yaml",
-        ["-s", "test-no-push-properties"],
-        0,
-        artifacts_in_file,
-    )
-
-
-def test_push_true():
-    artifacts_in_file = {
-        "test-push-true/test-push-true-dir/test1.txt": True,
-        "test-push-true/test-push-true-dir/test2.txt": True,
-        "test-push-true/test-push-true.txt": True,
-    }
-    _test_buildrunner_file(
-        f"{TEST_DIR}/test-files",
-        "test-push-artifact.yaml",
-        ["-s", "test-push-true"],
-        0,
-        artifacts_in_file,
-    )
-
-
-def test_push_false():
-    artifacts_in_file = {
-        "test-push-false/test-push-false-dir/test1.txt": False,
-        "test-push-false/test-push-false-dir/test2.txt": False,
-        "test-push-false/test-push-false.txt": False,
-    }
-    _test_buildrunner_file(
-        f"{TEST_DIR}/test-files",
-        "test-push-artifact.yaml",
-        ["-s", "test-push-false"],
-        0,
-        artifacts_in_file,
-    )
-
-
-def test_file_remame():
-    artifacts_in_file = {
-        "single-file-rename/hello-world.txt": True,
-        "single-file-rename/hello-world1.txt": True,
-        "single-file-rename/hello-world2.txt": True,
-        "single-file-rename/hello.txt": False,
-    }
-    _test_buildrunner_file(
-        f"{TEST_DIR}/test-files",
-        "test-push-artifact.yaml",
-        ["-s", "single-file-rename"],
-        0,
-        artifacts_in_file,
-    )
-
-
-def test_archive_file_remame():
-    artifacts_in_file = {
-        "archive-file-rename/dir1.tar.gz": True,
-        "archive-file-rename/dir1-dir2.tar.gz": True,
-        "archive-file-rename/dir3-dir2.tar.gz": True,
-        "archive-file-rename/dir2.tar.gz": False,
-    }
-    _test_buildrunner_file(
-        f"{TEST_DIR}/test-files",
-        "test-push-artifact.yaml",
-        ["-s", "archive-file-rename"],
+        "test-push-artifact-buildx.yaml",
+        ["-s", test_name],
         0,
         artifacts_in_file,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
Add use-legacy-builder flag to the get_source_image method. This is another step to eventually remove dependency on the legacy image builder.

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

