### PR TITLE
Fix intermittent test failures for missing busybox image

### DIFF
--- a/buildrunner/docker/daemon.py
+++ b/buildrunner/docker/daemon.py
@@ -74,8 +74,10 @@ class DockerDaemonProxy:
                 self._env["DOCKER_HOST"] = "unix:///dockerdaemon/docker.sock"
 
         # create and start the Docker container
+        image_name = f"{self.docker_registry}/busybox:latest"
+        self.docker_client.pull(image_name)
         self._daemon_container = self.docker_client.create_container(
-            f"{self.docker_registry}/busybox:latest",
+            image_name,
             command="/bin/sh",
             volumes=_volumes,
             host_config=self.docker_client.create_host_config(binds=_binds),

--- a/tests/test_push_artifact.py
+++ b/tests/test_push_artifact.py
@@ -21,6 +21,8 @@ def _test_buildrunner_file(
             top_dir_path,
             "-b",
             temp_dir,
+            # Since we are using a fresh temp directory, don't delete it first
+            "--keep-step-artifacts",
             "-f",
             os.path.join(test_dir, file_name),
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->
Fixes the intermittent test failures of "404 Client Error for http+docker://localhost/v1.45/containers/create: Not Found ("No such image: busybox:latest")". Prior to this PR there are some tests that would occasionally fail and retrying the test would often resolve the issue.

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

