### PR TITLE
Add retries and wait for secondary rate limits for publishing test re…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Test with pytest
       run: pytest -v --junitxml=test-reports/test-results.xml
     - name: Publish test results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      uses: EnricoMi/publish-unit-test-result-action/linux@v2
       if: always()
       with:
         files: test-reports/test-results.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,12 +52,13 @@ jobs:
     - name: Test with pytest
       run: pytest -v --junitxml=test-reports/test-results.xml
     - name: Publish test results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      # exclude this step for 3.6, since it fails due to a breaking change to EnricoMi/publish-unit-test-result-action
-      if: always() && matrix.python-version != '3.6'
+      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      if: always()
       with:
         files: test-reports/test-results.xml
         check_name: "Test Results ${{ matrix.python-version }}"
+        github_retries: 10
+        secondary_rate_limit_wait_seconds: 60.0
   tag-commit:
     if: github.repository == 'adobe/buildrunner' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
…sults to github

<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
Update `EnricoMi/publish-unit-test-result-action` to version 2. This should help with the secondary rate limit errors.

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->
This fixes the occasional test failures when publishing test results to github.
Example of the failure: `403 {"documentation_url": "https://docs.github.com/free-pro-team@latest/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits", "message": "You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 0400:D5008:5E2988:B581E8:66C61917."} `

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [ ] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

