### PR TITLE
Make sure to explicitly set cache-dir just in case

### DIFF
--- a/buildrunner/steprunner/tasks/push.py
+++ b/buildrunner/steprunner/tasks/push.py
@@ -254,7 +254,10 @@ class PushBuildStepRunnerTask(BuildStepRunnerTask):
             with open(
                 os.path.join(local_run_dir, config_file_name), "w", encoding="utf8"
             ) as fobj:
-                yaml.safe_dump(security_scan_config.config, fobj)
+                yaml.safe_dump(
+                    {"cache-dir": container_cache_dir, **security_scan_config.config},
+                    fobj,
+                )
 
             image_scanner = None
             try:

--- a/tests/test_push_security_scan.py
+++ b/tests/test_push_security_scan.py
@@ -353,14 +353,10 @@ def test__security_scan_trivy(
         "config.yaml",
         "results.json",
     }
-    assert (
-        yaml.safe_load((run_path / "config.yaml").read_text())
-        == security_scan_config.config
-    )
-    assert (
-        yaml.safe_load((run_path / "config.yaml").read_text())
-        == security_scan_config.config
-    )
+    assert yaml.safe_load((run_path / "config.yaml").read_text()) == {
+        "cache-dir": "/root/.cache/trivy",
+        **security_scan_config.config,
+    }
 
     docker_runner_mock.ImageConfig.assert_called_once_with(
         "registry1/aquasec/trivy:latest",


### PR DESCRIPTION
Just a quick fix to ensure that the trivy cache dir is set correctly (in case they ever change the default)