### PR TITLE
Convert fcntl to portalocker to be windows compatible

### DIFF
--- a/buildrunner/utils.py
+++ b/buildrunner/utils.py
@@ -217,7 +217,12 @@ def _acquire_flock_open(
     @timeout_decorator.timeout(
         seconds=timeout_seconds, timeout_exception=FailureToAcquireLockException
     )
-    def get_lock(file_obj, flags):
+    def get_lock(file_obj: io.IOBase):
+        flags = (
+            portalocker.LockFlags.EXCLUSIVE
+            if exclusive
+            else portalocker.LockFlags.SHARED
+        )
         portalocker.lock(
             file_obj,
             flags,
@@ -230,12 +235,7 @@ def _acquire_flock_open(
     pid = os.getpid()
 
     try:
-        flags = (
-            portalocker.LockFlags.EXCLUSIVE
-            if exclusive
-            else portalocker.LockFlags.SHARED
-        )
-        lock_file_obj = get_lock(file_obj, flags)
+        lock_file_obj = get_lock(file_obj)
     except FailureToAcquireLockException:
         file_obj.close()
         raise FailureToAcquireLockException(

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ pydantic>=2.4.2
 retry2>=0.9.5
 colorlog>=6.8.0
 rich>=13
+portalocker>=2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,8 @@ paramiko==3.2.0
     #   fabric
 pkginfo==1.9.6
     # via twine
+portalocker==2.10.1
+    # via -r requirements.in
 pycparser==2.21
     # via cffi
 pydantic==2.4.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
This PR converts fcntl to portalocker to be windows compatible. Fcntl does not work on non-Unix machines. Portalocker works on both Unix and Windows machines.

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [ ] I have updated the documentation or no documentation changes are required.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the base version in ``setup.py`` (if appropriate).

