### PR TITLE
Rollback python_on_whales conversion

### DIFF
--- a/buildrunner/docker/__init__.py
+++ b/buildrunner/docker/__init__.py
@@ -12,7 +12,6 @@ import tempfile
 from typing import Tuple
 import urllib.parse
 import docker
-import python_on_whales
 
 from buildrunner.errors import BuildRunnerError, BuildRunnerConfigurationError
 
@@ -96,21 +95,17 @@ def new_client(
     )
 
 
-def force_remove_container(docker_client, container, use_legacy_builder: bool):
+def force_remove_container(docker_client, container):
     """
     Force removes a container from the given docker client.
     :param docker_client: the docker client
     :param container: the container
-    :param use_legacy_builder: whether to use the legacy builder
     """
-    if use_legacy_builder:
-        docker_client.remove_container(
-            container,
-            force=True,
-            v=True,
-        )
-    else:
-        python_on_whales.docker.remove(container, force=True, volumes=True)
+    docker_client.remove_container(
+        container,
+        force=True,
+        v=True,
+    )
 
 
 def get_dockerfile(dockerfile: str, temp_dir: str = None) -> Tuple[str, bool]:

--- a/buildrunner/docker/builder.py
+++ b/buildrunner/docker/builder.py
@@ -277,9 +277,7 @@ class DockerBuilder:  # pylint: disable=too-many-instance-attributes
         # iterate through and destroy intermediate containers
         for container in self.intermediate_containers:
             try:
-                force_remove_container(
-                    self.docker_client, container, use_legacy_builder=True
-                )
+                force_remove_container(self.docker_client, container)
             except docker.errors.APIError as err:
                 logger.debug(
                     f"Error removing intermediate container {container}: {err}"

--- a/buildrunner/docker/daemon.py
+++ b/buildrunner/docker/daemon.py
@@ -8,9 +8,7 @@ with the terms of the Adobe license agreement accompanying it.
 
 import os
 
-import python_on_whales
 
-from buildrunner.config import BuildRunnerConfig
 from buildrunner.docker import DOCKER_DEFAULT_DOCKERD_URL
 
 DAEMON_IMAGE_NAME = "busybox:latest"
@@ -99,13 +97,8 @@ class DockerDaemonProxy:
             f"Destroying Docker daemon container {self._daemon_container:.10}\n"
         )
         if self._daemon_container:
-            if BuildRunnerConfig.get_instance().run_config.use_legacy_builder:
-                self.docker_client.remove_container(
-                    self._daemon_container,
-                    force=True,
-                    v=True,
-                )
-            else:
-                python_on_whales.docker.remove(
-                    self._daemon_container, force=True, volumes=True
-                )
+            self.docker_client.remove_container(
+                self._daemon_container,
+                force=True,
+                v=True,
+            )

--- a/buildrunner/docker/importer.py
+++ b/buildrunner/docker/importer.py
@@ -6,13 +6,11 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in accordance
 with the terms of the Adobe license agreement accompanying it.
 """
 
-import python_on_whales
 import yaml
 
 import docker
 import docker.errors
 
-from buildrunner.config import BuildRunnerConfig
 from buildrunner.docker import new_client
 from buildrunner.errors import BuildRunnerProcessingError
 from buildrunner.utils import is_dict
@@ -43,11 +41,7 @@ class DockerImporter:
         """
 
         try:
-            import_return = None
-            if BuildRunnerConfig.get_instance().run_config.use_legacy_builder:
-                import_return = self.docker_client.import_image(self.src)
-            else:
-                import_return = python_on_whales.docker.import_(self.src)
+            import_return = self.docker_client.import_image(self.src)
         except docker.errors.APIError as apie:
             raise BuildRunnerProcessingError(
                 f"Error importing image from archive file {self.src}: {apie}"

--- a/buildrunner/steprunner/tasks/build.py
+++ b/buildrunner/steprunner/tasks/build.py
@@ -16,7 +16,7 @@ import buildrunner.docker
 from buildrunner.config import BuildRunnerConfig
 from buildrunner.config.models_step import StepBuild
 from buildrunner.docker.importer import DockerImporter
-import buildrunner.docker.builder as legacy_builder
+import buildrunner.docker.builder
 from buildrunner.errors import (
     BuildRunnerConfigurationError,
 )
@@ -262,7 +262,7 @@ class BuildBuildStepRunnerTask(BuildStepRunnerTask):  # pylint: disable=too-many
 
             else:
                 # Use the legacy builder
-                image = legacy_builder.build_image(
+                image = buildrunner.docker.builder.build_image(
                     path=self.path,
                     inject=self.to_inject,
                     dockerfile=self.dockerfile,

--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -1134,18 +1134,11 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             self.step_runner.log.write(
                 f"Destroying source container {self._source_container:.10}\n"
             )
-            if BuildRunnerConfig.get_instance().run_config.use_legacy_builder:
-                self._docker_client.remove_container(
-                    self._source_container,
-                    force=True,
-                    v=True,
-                )
-            else:
-                python_on_whales.docker.container.remove(
-                    self._source_container,
-                    force=True,
-                    volumes=True,
-                )
+            self._docker_client.remove_container(
+                self._source_container,
+                force=True,
+                v=True,
+            )
 
         for image in self.images_to_remove:
             python_on_whales.docker.image.remove(image, force=True)

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -183,7 +183,7 @@ def fixture_set_env():
     ],
 )
 @mock.patch(
-    "tests.test_runner.buildrunner.steprunner.tasks.build.legacy_builder.build_image"
+    "tests.test_runner.buildrunner.steprunner.tasks.build.buildrunner.docker.builder.build_image"
 )
 @mock.patch(
     "tests.test_runner.buildrunner.steprunner.MultiplatformImageBuilder.build_multiple_images"

--- a/tests/test_buildrunner_files.py
+++ b/tests/test_buildrunner_files.py
@@ -1,4 +1,5 @@
 import os
+import random
 import pytest
 import platform
 import subprocess
@@ -185,7 +186,7 @@ def test_buildrunner_arm_dir(test_dir: str, file_name, args, exit_code):
     _test_buildrunner_file(test_dir, file_name, args, exit_code)
 
 
-@pytest.mark.flaky(reruns=2, reruns_delay=1)
+@pytest.mark.flaky(reruns=5, reruns_delay=random.randint(1, 5))
 @pytest.mark.parametrize(
     "test_dir, file_name, args, exit_code",
     _get_test_runs(test_dir=f"{TEST_DIR}/test-files/scan", serial_tests=False),

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -34,19 +34,15 @@ def fixture_setup_runner():
         "docker.io/ubuntu:19.04",
         pull_image=False,
     )
-    with mock.patch(
-        "buildrunner.docker.runner.BuildRunnerConfig.get_instance"
-    ) as mock_build_runner_config:
-        #  Set to use docker-py to be used over python on whales
-        mock_build_runner_config.run_config.use_legacy_builder.return_value = True
-        runner = DockerRunner(
-            image_config=image_config,
-        )
-        runner.start(working_dir="/root")
 
-        yield runner
+    runner = DockerRunner(
+        image_config=image_config,
+    )
+    runner.start(working_dir="/root")
 
-        runner.cleanup()
+    yield runner
+
+    runner.cleanup()
 
 
 @pytest.fixture(name="log_output")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
Rollback previous attempts to convert `docker-py` calls with `python-on-whales`, except for building multi-platform images which is not possible with `docker-py`. It was determined that the pitfalls and current limitations with python-on-whales that it was worth the effort to convert totally over to it at this time. The PR rollbacks those changes in a single commit to make the code more concise and readable.

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [ ] I have updated the documentation or no documentation changes are required.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the base version in ``setup.py`` (if appropriate).

