### PR TITLE
Add support for systemd v248+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PIP_DEFAULT_TIMEOUT 60
 
 # Install the docker client for multiplatform builds
 RUN apt update && \
-    apt install ca-certificates curl && \
+    apt -y install ca-certificates curl && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \

--- a/README.rst
+++ b/README.rst
@@ -640,6 +640,12 @@ the run step:
         # 'BUILDRUNNER_SYSTEMD'.
         # If found, systemd=true will be assumed.
         systemd: true/false
+        # (Ignored when systemd is not enabled)
+        # For systemd 248+, a read-write mount for /sys/fs/cgroup is required as well as a tmpfs mounted at /run, and
+        # this flag enables this behavior
+        # If this is ommitted, the image will be inspected for the label
+        # 'BUILDRUNNER_SYSTEMD_V248' and that value will be used instead.
+        systemd_v248: true/false
 
         # Docker supports certain kernel capabilities, like 'SYS_ADMIN'.
         # see https://goo.gl/gTQrqW for more infromation on setting these.

--- a/buildrunner/config/models_step.py
+++ b/buildrunner/config/models_step.py
@@ -104,6 +104,7 @@ class RunAndServicesBase(StepTask):
     ports: Optional[Dict[int, Optional[int]]] = None
     pull: Optional[bool] = None
     systemd: Optional[bool] = None
+    systemd_v248: Optional[bool] = None
     containers: Optional[List[str]] = None
     caches: Optional[Dict[str, Union[str, List[str]]]] = None
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = "3.13"
+BASE_VERSION = "3.14"
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BUILDRUNNER_DIR = os.path.join(SOURCE_DIR, "buildrunner")

--- a/tests/test-files/test-systemd.yaml
+++ b/tests/test-files/test-systemd.yaml
@@ -61,6 +61,16 @@ steps:
     run:
        systemd: true
        cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
+  test-systemd-v248-on:
+    build:
+      dockerfile: |
+        # Rocky linux 9 has 248+ installed
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:9.0
+        RUN yum install -y procps-ng && yum clean all
+    run:
+       systemd: true
+       systemd_v248: true
+       cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
 
   test-systemd-on-built:
     build:
@@ -68,6 +78,16 @@ steps:
         FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
         RUN yum install -y procps-ng && yum clean all
         LABEL BUILDRUNNER_SYSTEMD=1
+    run:
+      cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
+
+  test-systemd-v248-on-built:
+    build:
+      dockerfile: |
+        FROM {{ DOCKER_REGISTRY }}/rockylinux:9.0
+        RUN yum install -y procps-ng && yum clean all
+        LABEL BUILDRUNNER_SYSTEMD=1
+        LABEL BUILDRUNNER_SYSTEMD_V248=1
     run:
       cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
 
@@ -93,6 +113,21 @@ steps:
               FROM {{ DOCKER_REGISTRY }}/rockylinux:8.5
               RUN yum -y install python3 procps-ng && yum clean all
               LABEL BUILDRUNNER_SYSTEMD=1
+          systemd: true
+          cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init && python3 -m http.server 8001
+      image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
+      pull: false
+      cmd: curl http://s1:8001 1>/dev/null 2>&1
+  test-systemd-v248-service:
+    run:
+      services:
+        s1:
+          build:
+            dockerfile: |
+              FROM {{ DOCKER_REGISTRY }}/rockylinux:9.0
+              RUN yum -y install python3 procps-ng && yum clean all
+              LABEL BUILDRUNNER_SYSTEMD=1
+              LABEL BUILDRUNNER_SYSTEMD_V248=1
           systemd: true
           cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init && python3 -m http.server 8001
       image: {{ DOCKER_REGISTRY }}/rockylinux:8.5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
Systemd v248+ requires new parameters to work correctly with docker. These are documented in https://github.com/moby/moby/issues/42275.

### What issues does this PR fix or reference?
It adds support for a new config flag to enable the new behavior.

### Previous Behavior
Hard failure when using the systemd flag with v248+

### New Behavior
systemd works correctly

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

