### PR TITLE
Improve cgroup v2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -641,11 +641,11 @@ the run step:
         # If found, systemd=true will be assumed.
         systemd: true/false
         # (Ignored when systemd is not enabled)
-        # For systemd 248+, a read-write mount for /sys/fs/cgroup is required as well as a tmpfs mounted at /run, and
+        # For cgroup v2, a read-write mount for /sys/fs/cgroup is required as well as a tmpfs mounted at /run, and
         # this flag enables this behavior
-        # If this is ommitted, the image will be inspected for the label
-        # 'BUILDRUNNER_SYSTEMD_V248' and that value will be used instead.
-        systemd_v248: true/false
+        # If this is omitted, the image will be inspected for the label
+        # 'BUILDRUNNER_SYSTEMD_CGROUP2' and that value will be used instead.
+        systemd_cgroup2: true/false
 
         # Docker supports certain kernel capabilities, like 'SYS_ADMIN'.
         # see https://goo.gl/gTQrqW for more infromation on setting these.

--- a/buildrunner/config/models_step.py
+++ b/buildrunner/config/models_step.py
@@ -104,7 +104,7 @@ class RunAndServicesBase(StepTask):
     ports: Optional[Dict[int, Optional[int]]] = None
     pull: Optional[bool] = None
     systemd: Optional[bool] = None
-    systemd_v248: Optional[bool] = None
+    systemd_cgroup2: Optional[bool] = None
     containers: Optional[List[str]] = None
     caches: Optional[Dict[str, Union[str, List[str]]]] = None
 

--- a/buildrunner/docker/runner.py
+++ b/buildrunner/docker/runner.py
@@ -150,7 +150,7 @@ class DockerRunner:
         extra_hosts=None,
         containers=None,
         systemd: bool = False,
-        systemd_v248: bool = False,
+        systemd_cgroup2: bool = False,
         cap_add=None,
         privileged=False,
     ):  # pylint: disable=too-many-arguments,too-many-locals
@@ -178,7 +178,7 @@ class DockerRunner:
         if systemd:
             # If we are running in a systemd context, the following 3 settings are necessary to
             # allow services to run.
-            if systemd_v248:
+            if systemd_cgroup2:
                 volumes["/sys/fs/cgroup/buildrunner.scope"] = "/sys/fs/cgroup:rw"
                 tmpfs["/run"] = ""
                 cgroupns = "host"

--- a/buildrunner/docker/runner.py
+++ b/buildrunner/docker/runner.py
@@ -10,6 +10,7 @@ import base64
 import datetime
 import io
 import os.path
+import platform
 import socket
 import ssl
 from collections import OrderedDict
@@ -179,6 +180,14 @@ class DockerRunner:
             # If we are running in a systemd context, the following 3 settings are necessary to
             # allow services to run.
             if systemd_cgroup2:
+                # Ensure that cgroup v2 is supported before attempting to use it
+                # Note: this check only works on linux systems
+                if platform.system() == "Linux" and not os.path.exists(
+                    "/sys/fs/cgroup/cgroup.controllers"
+                ):
+                    raise BuildRunnerContainerError(
+                        "cgroup v2 is not enabled on this host but is set on the container, please check configuration"
+                    )
                 volumes["/sys/fs/cgroup/buildrunner.scope"] = "/sys/fs/cgroup:rw"
                 tmpfs["/run"] = ""
                 cgroupns = "host"

--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -616,7 +616,7 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             working_dir=_cwd,
             containers=_containers,
             systemd=systemd,
-            systemd_v248=self.is_systemd_v248(systemd, service, _image),
+            systemd_cgroup2=self.is_systemd_cgroup2(systemd, service, _image),
         )
         self._service_links[cont_name] = name
 
@@ -1025,7 +1025,7 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             )
             # Figure out if we should be running systemd.  Has to happen after docker pull
             container_args["systemd"] = self.is_systemd(self.step, _run_image)
-            container_args["systemd_v248"] = self.is_systemd_v248(
+            container_args["systemd_cgroup2"] = self.is_systemd_cgroup2(
                 container_args["systemd"], self.step, _run_image
             )
 
@@ -1164,16 +1164,16 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             return run_service.systemd
         return self._get_label_is_truthy(image, "BUILDRUNNER_SYSTEMD")
 
-    def is_systemd_v248(
+    def is_systemd_cgroup2(
         self, systemd: bool, run_service: RunAndServicesBase, image: str
     ) -> bool:
         """
-        Check if an image needs the changes for systemd v248+
+        Check if an image needs the changes for cgroup2
         """
         if not systemd:
             # Do not run any other checks if we are not using systemd at all
             return False
 
-        if run_service.systemd_v248 is not None:
-            return run_service.systemd_v248
-        return self._get_label_is_truthy(image, "BUILDRUNNER_SYSTEMD_V248")
+        if run_service.systemd_cgroup2 is not None:
+            return run_service.systemd_cgroup2
+        return self._get_label_is_truthy(image, "BUILDRUNNER_SYSTEMD_CGROUP2")

--- a/tests/test-files/test-systemd.yaml
+++ b/tests/test-files/test-systemd.yaml
@@ -61,15 +61,15 @@ steps:
     run:
        systemd: true
        cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
-  test-systemd-v248-on:
+  test-systemd-cgroup2-on:
     build:
       dockerfile: |
-        # Rocky linux 9 has 248+ installed
+        # Rocky linux 9 has systemd 248+ installed
         FROM {{ DOCKER_REGISTRY }}/rockylinux:9.0
         RUN yum install -y procps-ng && yum clean all
     run:
        systemd: true
-       systemd_v248: true
+       systemd_cgroup2: true
        cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
 
   test-systemd-on-built:
@@ -81,13 +81,13 @@ steps:
     run:
       cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
 
-  test-systemd-v248-on-built:
+  test-systemd-cgroup2-on-built:
     build:
       dockerfile: |
         FROM {{ DOCKER_REGISTRY }}/rockylinux:9.0
         RUN yum install -y procps-ng && yum clean all
         LABEL BUILDRUNNER_SYSTEMD=1
-        LABEL BUILDRUNNER_SYSTEMD_V248=1
+        LABEL BUILDRUNNER_SYSTEMD_CGROUP2=1
     run:
       cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init
 
@@ -118,7 +118,7 @@ steps:
       image: {{ DOCKER_REGISTRY }}/rockylinux:8.5
       pull: false
       cmd: curl http://s1:8001 1>/dev/null 2>&1
-  test-systemd-v248-service:
+  test-systemd-cgroup2-service:
     run:
       services:
         s1:
@@ -127,7 +127,7 @@ steps:
               FROM {{ DOCKER_REGISTRY }}/rockylinux:9.0
               RUN yum -y install python3 procps-ng && yum clean all
               LABEL BUILDRUNNER_SYSTEMD=1
-              LABEL BUILDRUNNER_SYSTEMD_V248=1
+              LABEL BUILDRUNNER_SYSTEMD_CGROUP2=1
           systemd: true
           cmd: ps -p 1 -o cmd | tail -1 | grep /usr/sbin/init && python3 -m http.server 8001
       image: {{ DOCKER_REGISTRY }}/rockylinux:8.5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
Renames systemd v248 flags to systemd cgroup2, since that's really what it is about. Also adds a check to make sure it will work properly on linux systems.

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

