### PR TITLE
Handle container errors correctly

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -18,6 +18,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import traceback
 import types
 from typing import List, Optional
 
@@ -35,6 +36,7 @@ from buildrunner.config.models import DEFAULT_CACHES_ROOT
 from buildrunner.errors import (
     BuildRunnerConfigurationError,
     BuildRunnerProcessingError,
+    BuildRunnerError,
 )
 from buildrunner.steprunner import BuildStepRunner
 from buildrunner.docker.multiplatform_image_builder import MultiplatformImageBuilder
@@ -470,13 +472,6 @@ class BuildRunner:
                         )
                 else:
                     self.log.write("\nPush not requested\n")
-
-        except BuildRunnerConfigurationError as brce:
-            exit_explanation = str(brce)
-            self.exit_code = os.EX_CONFIG
-        except BuildRunnerProcessingError as brpe:
-            exit_explanation = str(brpe)
-            self.exit_code = 1
         except requests.exceptions.ConnectionError as rce:
             print(str(rce))
             exit_explanation = (
@@ -485,6 +480,14 @@ class BuildRunner:
                 "environment variables are set correctly.\n\tCheck that the "
                 "remote PyPi server information is set correctly."
             )
+            self.exit_code = 1
+        except BuildRunnerError as exc:
+            exit_explanation = str(exc)
+            self.exit_code = (
+                os.EX_CONFIG if isinstance(exc, BuildRunnerConfigurationError) else 1
+            )
+        except Exception as exc:
+            exit_explanation = f"Encountered unhandled exception ({type(exc).__name__}) {traceback.format_exc()}"
             self.exit_code = 1
 
         finally:

--- a/tests/config-files/dot-buildrunner.yaml
+++ b/tests/config-files/dot-buildrunner.yaml
@@ -32,3 +32,7 @@ caches-root: ~/.buildrunner/caches
 # buildrunner scripts
 env:
   GLOBAL_VAR1: 'value1'
+
+# The 'docker-registry' global configuration specifies the default docker registry
+# Use the AWS public ECR as it has higher rate limits than Docker Hub
+docker-registry: public.ecr.aws/docker/library


### PR DESCRIPTION
Currently container errors (and other unknown errors) show a successful build, but this should fail with an error message and potentially a traceback if the exception is unhandled explicitly.