### PR TITLE
Add ability to label all started containers

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -85,6 +85,7 @@ class BuildRunner:
         local_images: bool,
         platform: Optional[str],
         global_config_overrides: dict,
+        container_labels: Optional[str] = None,
     ):  # pylint: disable=too-many-statements,too-many-branches,too-many-locals,too-many-arguments
         self.build_dir = build_dir
         self.build_results_dir = build_results_dir
@@ -141,6 +142,7 @@ class BuildRunner:
             build_time=self.build_time,
             tmp_files=self.tmp_files,
             global_config_overrides=global_config_overrides,
+            container_labels=container_labels,
         )
         self.buildrunner_config = BuildRunnerConfig.get_instance()
 

--- a/buildrunner/cli.py
+++ b/buildrunner/cli.py
@@ -69,6 +69,15 @@ def parse_args(argv):
     )
 
     parser.add_argument(
+        "--container-labels",
+        default=None,
+        help=(
+            "arbitrary labels to add to every container started by buildrunner, "
+            "in the form of 'key1=value1,key2=value2'"
+        ),
+    )
+
+    parser.add_argument(
         "-n",
         "--build-number",
         default=None,
@@ -396,6 +405,7 @@ def initialize_br(args: argparse.Namespace) -> BuildRunner:
         local_images=args.local_images,
         platform=args.platform,
         global_config_overrides=_get_global_config_overrides(args),
+        container_labels=args.container_labels,
     )
 
 

--- a/buildrunner/docker/runner.py
+++ b/buildrunner/docker/runner.py
@@ -27,6 +27,7 @@ import docker.errors
 import six
 import timeout_decorator
 
+from buildrunner import BuildRunnerConfig
 from buildrunner.docker import (
     new_client,
     force_remove_container,
@@ -79,10 +80,10 @@ class DockerRunner:
     def __init__(self, image_config, dockerd_url=None, log=None):
         image_name = image_config.image_name
         pull_image = image_config.pull_image
-        platform = image_config.platform
+        image_platform = image_config.platform
 
         self.image_name = image_name.lower()
-        self.platform = platform
+        self.platform = image_platform
         if log and self.image_name != image_name:
             log.write(
                 f"Forcing image_name to lowercase: {image_name} => {self.image_name}\n"
@@ -230,6 +231,7 @@ class DockerRunner:
             "user": user,
             "working_dir": working_dir,
             "hostname": hostname,
+            "labels": BuildRunnerConfig.get_instance().container_labels,
             "host_config": self.docker_client.create_host_config(
                 binds=_binds,
                 links=links,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = "3.14"
+BASE_VERSION = "3.15"
 
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BUILDRUNNER_DIR = os.path.join(SOURCE_DIR, "buildrunner")

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -7,7 +7,7 @@ from os.path import isfile, join
 from time import sleep
 from unittest import mock
 
-from buildrunner import BuildRunner
+from buildrunner import BuildRunner, BuildRunnerConfig
 from buildrunner.docker.runner import DockerRunner
 from buildrunner.loggers import ConsoleLogger
 import pytest
@@ -26,6 +26,25 @@ def _tar_safe_extractall(tar, path=".", members=None, *, numeric_owner=False):
         if not _tar_is_within_directory(path, member_path):
             raise Exception("Attempted path traversal in tar file")
     tar.extractall(path, members, numeric_owner=numeric_owner)
+
+
+@pytest.fixture(name="initialize_config", autouse=True)
+def fixture_initialize_config(tmp_path):
+    buildrunner_path = tmp_path / "buildrunner.yaml"
+    buildrunner_path.write_text("steps: {'step1': {}}")
+    BuildRunnerConfig.initialize_instance(
+        build_id="123",
+        vcs=None,
+        build_dir=str(tmp_path),
+        global_config_file=None,
+        run_config_file=str(buildrunner_path),
+        build_time=0,
+        build_number=1,
+        push=False,
+        steps_to_run=None,
+        log_generated_files=False,
+        global_config_overrides={},
+    )
 
 
 @pytest.fixture(name="runner")

--- a/tests/test_config_validation/test_container_labels.py
+++ b/tests/test_config_validation/test_container_labels.py
@@ -1,0 +1,64 @@
+import os
+from unittest import mock
+
+import pytest
+
+from buildrunner import BuildRunner, BuildRunnerConfig
+
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+BLANK_GLOBAL_CONFIG = os.path.join(TEST_DIR, "files/blank_global_config.yaml")
+
+
+@pytest.mark.parametrize(
+    "container_labels, result_labels",
+    [
+        (None, {}),
+        ("", {}),
+        ("key1=val1", {"key1": "val1"}),
+        ("key1=val1,key2=val2", {"key1": "val1", "key2": "val2"}),
+        ("key1=val1=val3,key2=val2", {"key1": "val1=val3", "key2": "val2"}),
+    ],
+)
+@mock.patch("buildrunner.detect_vcs")
+def test_container_labels(
+    detect_vcs_mock,
+    container_labels,
+    result_labels,
+    tmp_path,
+):
+    id_string = "main-921.ie02ed8.m1705616822"
+    type(detect_vcs_mock.return_value).id_string = mock.PropertyMock(
+        return_value=id_string
+    )
+    buildrunner_path = tmp_path / "buildrunner.yaml"
+    buildrunner_path.write_text(
+        """
+        steps:
+            build-container:
+                build:
+                    dockerfile: |
+                        FROM {{ DOCKER_REGISTRY }}/nginx:latest
+                        RUN printf '{{ BUILDRUNNER_BUILD_NUMBER }}' > /usr/share/nginx/html/index.html
+        """
+    )
+    BuildRunner(
+        build_dir=str(tmp_path),
+        build_results_dir=str(tmp_path / "buildrunner.results"),
+        global_config_file=None,
+        run_config_file=str(buildrunner_path),
+        build_time=0,
+        build_number=1,
+        push=False,
+        cleanup_images=False,
+        cleanup_cache=False,
+        steps_to_run=None,
+        publish_ports=False,
+        log_generated_files=False,
+        docker_timeout=30,
+        local_images=False,
+        platform=None,
+        global_config_overrides={},
+        container_labels=container_labels,
+    )
+    assert BuildRunnerConfig.get_instance().container_labels == result_labels


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
Adds the capability to automatically add labels to all containers started with buildrunner. This will track down bag agents that do not clean up properly, etc.

### What issues does this PR fix or reference?
Internal issue only

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base version in ``setup.py`` (if appropriate).

