### PR TITLE
Pass docker container labels to daemon and ssh-agent container creation

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -399,7 +399,12 @@ class BuildRunner:
                             multi_platform.set_cache_to(step_config.build.cache_to)
 
                         self._step_runner = BuildStepRunner(
-                            self, step_name, step_config, image_config, multi_platform
+                            self,
+                            step_name,
+                            step_config,
+                            image_config,
+                            multi_platform,
+                            self.buildrunner_config.container_labels
                         )
                         self._step_runner.run()
 

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -404,7 +404,7 @@ class BuildRunner:
                             step_config,
                             image_config,
                             multi_platform,
-                            self.buildrunner_config.container_labels
+                            self.buildrunner_config.container_labels,
                         )
                         self._step_runner.run()
 

--- a/buildrunner/docker/daemon.py
+++ b/buildrunner/docker/daemon.py
@@ -19,11 +19,12 @@ class DockerDaemonProxy:
     Class used to encapsulate Docker daemon information within a container.
     """
 
-    def __init__(self, docker_client, log, docker_registry):
+    def __init__(self, docker_client, log, docker_registry, container_labels):
         """ """
         self.docker_client = docker_client
         self.docker_registry = docker_registry
         self.log = log
+        self.container_labels = container_labels
         self._daemon_container = None
         self._env = {
             "DOCKER_HOST": DOCKER_DEFAULT_DOCKERD_URL,

--- a/buildrunner/sshagent/__init__.py
+++ b/buildrunner/sshagent/__init__.py
@@ -89,7 +89,12 @@ class DockerSSHAgentProxy:
     """
 
     def __init__(
-        self, docker_client, log, docker_registry, multiplatform_image_builder, container_labels
+        self,
+        docker_client,
+        log,
+        docker_registry,
+        multiplatform_image_builder,
+        container_labels,
     ):
         """ """
         self.docker_client = docker_client
@@ -135,7 +140,6 @@ class DockerSSHAgentProxy:
             labels=self._container_labels,
             host_config=self.docker_client.create_host_config(
                 publish_all_ports=True,
-
             ),
         )["Id"]
         self.docker_client.start(

--- a/buildrunner/sshagent/__init__.py
+++ b/buildrunner/sshagent/__init__.py
@@ -89,7 +89,7 @@ class DockerSSHAgentProxy:
     """
 
     def __init__(
-        self, docker_client, log, docker_registry, multiplatform_image_builder
+        self, docker_client, log, docker_registry, multiplatform_image_builder, container_labels
     ):
         """ """
         self.docker_client = docker_client
@@ -100,6 +100,7 @@ class DockerSSHAgentProxy:
         self._ssh_client = None
         self._ssh_channel = None
         self._multiplatform_image_builder = multiplatform_image_builder
+        self._container_labels = container_labels
 
     def get_info(self):
         """
@@ -131,8 +132,10 @@ class DockerSSHAgentProxy:
             command=[
                 f"{keys[0].get_name()} {keys[0].get_base64()}",
             ],
+            labels=self._container_labels,
             host_config=self.docker_client.create_host_config(
                 publish_all_ports=True,
+
             ),
         )["Id"]
         self.docker_client.start(

--- a/buildrunner/steprunner/__init__.py
+++ b/buildrunner/steprunner/__init__.py
@@ -53,6 +53,7 @@ class BuildStepRunner:  # pylint: disable=too-many-instance-attributes
         step: Step,
         image_config,
         multi_platform: MultiplatformImageBuilder,
+        container_labels,
     ):
         """
         Constructor.
@@ -78,6 +79,7 @@ class BuildStepRunner:  # pylint: disable=too-many-instance-attributes
         # generate a unique step id
         self.id = str(uuid.uuid4())  # pylint: disable=invalid-name
         self.multi_platform = multi_platform
+        self.container_labels = container_labels
 
     def run(self):
         """

--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -83,6 +83,7 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             self._source_container = self._docker_client.create_container(
                 self.step_runner.build_runner.get_source_image(),
                 command="/bin/sh",
+                labels=self.step_runner.container_labels,
             )["Id"]
             self._docker_client.start(
                 self._source_container,
@@ -828,6 +829,7 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
                 self.step_runner.log,
                 buildrunner_config.global_config.docker_registry,
                 self.step_runner.multi_platform,
+                self.step_runner.container_labels,
             )
             self._sshagent.start(
                 buildrunner_config.get_ssh_keys_from_aliases(
@@ -840,6 +842,7 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             self._docker_client,
             self.step_runner.log,
             buildrunner_config.global_config.docker_registry,
+            self.step_runner.container_labels,
         )
         self._dockerdaemonproxy.start()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
The --container-labels parameter is not passed to the daemon or ssh-agent containers when created

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->
Container labels missing from containers associated with build

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the base version in ``setup.py`` (if appropriate).

