### PR TITLE
XENG-8914 include last element in run_config_file in network name, if…

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -89,6 +89,7 @@ class BuildRunner:
     ):  # pylint: disable=too-many-statements,too-many-branches,too-many-locals,too-many-arguments
         self.build_dir = build_dir
         self.build_results_dir = build_results_dir
+        self.run_config_file = run_config_file
         self.build_time = build_time
         self.build_number = build_number
         self.push = push

--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -89,7 +89,6 @@ class BuildRunner:
     ):  # pylint: disable=too-many-statements,too-many-branches,too-many-locals,too-many-arguments
         self.build_dir = build_dir
         self.build_results_dir = build_results_dir
-        self.run_config_file = run_config_file
         self.build_time = build_time
         self.build_number = build_number
         self.push = push

--- a/buildrunner/steprunner/__init__.py
+++ b/buildrunner/steprunner/__init__.py
@@ -82,6 +82,8 @@ class BuildStepRunner:  # pylint: disable=too-many-instance-attributes
         self.container_labels = container_labels
         # network name is used to identify the network that the build step is running in
         self.network_name = f"{build_runner.build_id}-{step_name}"
+        if build_runner.run_config_file:
+            self.network_name += f"-{os.path.basename(os.path.dirname(os.path.abspath(build_runner.run_config_file)))}"
 
     def run(self):
         """

--- a/buildrunner/steprunner/__init__.py
+++ b/buildrunner/steprunner/__init__.py
@@ -81,9 +81,7 @@ class BuildStepRunner:  # pylint: disable=too-many-instance-attributes
         self.multi_platform = multi_platform
         self.container_labels = container_labels
         # network name is used to identify the network that the build step is running in
-        self.network_name = f"{build_runner.build_id}-{step_name}"
-        if build_runner.run_config_file:
-            self.network_name += f"-{os.path.basename(os.path.dirname(os.path.abspath(build_runner.run_config_file)))}"
+        self.network_name = f"{self.id}-network"
 
     def run(self):
         """


### PR DESCRIPTION
… it exists

<!--- Provide a general summary of your changes in the Title above -->
In the case of a parallel Jenkins job that calls buildrunner multiple times for different buildrunner.yaml files with the same step names, but in different directories, a network name will be unique to the buildrunner.yaml file directory

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [ ] I have updated the documentation or no documentation changes are required.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the base version in ``setup.py`` (if appropriate).

