### PR TITLE
Add container cleanup to handle SIGTERM/SIGINT scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ curator.results
 # Ignore all .tar files
 # Manually running of some example files may create local .tar files
 *.tar
+
+.claude

--- a/README.rst
+++ b/README.rst
@@ -1023,7 +1023,7 @@ The configuration may also specify additional tags to add to the image:
           # See docs/global-configuration.rst for more information on these attributes.
           #enabled: false
           #scanner: "trivy"
-          #version: "latest"
+          #version: "0.69.3"
           # NOTE: Any configuration provided here will be merged with global/command line config
           #config:
           #  optional-param: val1

--- a/buildrunner/cleanup.py
+++ b/buildrunner/cleanup.py
@@ -1,0 +1,112 @@
+"""
+Copyright 2026 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in accordance
+with the terms of the Adobe license agreement accompanying it.
+"""
+
+import atexit
+import os
+import signal
+import sys
+
+# Global registry of container IDs started by this buildrunner process.
+# Used by the signal handler to force-remove containers on abort.
+#
+# Design notes:
+# - No threading.Lock: signal handlers in Python run in the main thread and
+#   must not acquire locks (deadlock risk). Python's GIL makes list.append()
+#   and list snapshot (list(...)) atomic enough for this use case.
+# - No logging in signal handler: logging acquires internal locks.
+# - _cleanup_done is a simple bool flag; only the main thread writes it.
+
+_registered_containers: list[str] = []
+_docker_client = None
+_cleanup_done = False
+
+
+def set_docker_client(client) -> None:
+    """Set the Docker client used for cleanup. Call from main thread after client init."""
+    global _docker_client
+    _docker_client = client
+
+
+def register_container(container_id: str) -> None:
+    """Register a container for cleanup on signal/exit."""
+    if container_id and container_id not in _registered_containers:
+        _registered_containers.append(container_id)
+
+
+def unregister_container(container_id: str) -> None:
+    """Unregister a container after successful removal."""
+    try:
+        _registered_containers.remove(container_id)
+    except ValueError:
+        pass
+
+
+def _force_cleanup_all() -> None:
+    """Force-remove all registered containers.
+
+    Called from:
+    - atexit hook (normal exit, unhandled exception)
+    - signal handler (SIGTERM/SIGINT from CI system aborting the build)
+
+    Safe to call multiple times; only the first call does work.
+    """
+    global _cleanup_done
+    if _cleanup_done:
+        return
+    _cleanup_done = True
+
+    # Snapshot the list — no lock needed, GIL protects list copy
+    containers = list(_registered_containers)
+    if not containers:
+        return
+
+    client = _docker_client
+    if not client:
+        try:
+            import docker as docker_module
+
+            client = docker_module.from_env()
+        except Exception:
+            # No way to reach Docker — print to stderr (signal-safe)
+            print(
+                f"buildrunner cleanup: cannot create Docker client, "
+                f"{len(containers)} container(s) may be orphaned",
+                file=sys.stderr,
+            )
+            return
+
+    print(
+        f"buildrunner cleanup: removing {len(containers)} container(s)",
+        file=sys.stderr,
+    )
+
+    for cid in containers:
+        try:
+            client.remove_container(cid, force=True, v=True)
+        except Exception:
+            # Container may already be removed by normal cleanup — that's fine
+            pass
+
+
+def _signal_handler(signum, _frame):
+    """Handle SIGTERM/SIGINT by cleaning up containers then exiting.
+
+    Avoids logging, locks, and complex operations to remain signal-safe.
+    Uses os._exit() instead of sys.exit() to prevent finally blocks from
+    running (which would race with the cleanup we just did).
+    """
+    _force_cleanup_all()
+    # os._exit() skips finally blocks and atexit — we already cleaned up
+    os._exit(128 + signum)
+
+
+def install_signal_handlers() -> None:
+    """Install SIGTERM/SIGINT handlers and atexit hook for container cleanup."""
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+    atexit.register(_force_cleanup_all)

--- a/buildrunner/cli.py
+++ b/buildrunner/cli.py
@@ -19,7 +19,8 @@ from . import (
     BuildRunner,
     BuildRunnerConfigurationError,
 )
-from buildrunner import config, loggers
+from buildrunner import config, docker as br_docker, loggers
+from buildrunner.cleanup import install_signal_handlers, set_docker_client
 from buildrunner.config import BuildRunnerConfig
 from buildrunner.utils import epoch_time
 
@@ -417,8 +418,17 @@ def main():
         print(__version__)
         return os.EX_OK
 
+    # Install signal handlers so that SIGTERM/SIGINT (e.g. from CI system aborting
+    # a build) triggers cleanup of all Docker containers started by this process.
+    install_signal_handlers()
+
     try:
         build_runner = initialize_br(args)
+        # Give the cleanup module access to the Docker client for signal-time cleanup
+        try:
+            set_docker_client(br_docker.new_client())
+        except Exception:
+            pass  # Cleanup will create its own client if needed
         if not args.print_generated_files:
             build_runner.run()
             if build_runner.exit_code:

--- a/buildrunner/config/models.py
+++ b/buildrunner/config/models.py
@@ -56,7 +56,7 @@ class GlobalSecurityScanConfig(BaseModel, extra="forbid"):
 
     enabled: bool = False
     scanner: str = "trivy"
-    version: str = "latest"
+    version: str = "0.69.3"
     # The local cache directory for the scanner (used if supported by the scanner)
     cache_dir: Optional[str] = Field(None, alias="cache-dir")
     config: dict = {

--- a/buildrunner/docker/daemon.py
+++ b/buildrunner/docker/daemon.py
@@ -9,6 +9,7 @@ with the terms of the Adobe license agreement accompanying it.
 import os
 
 
+from buildrunner.cleanup import register_container, unregister_container
 from buildrunner.docker import DOCKER_DEFAULT_DOCKERD_URL
 
 DAEMON_IMAGE_NAME = "busybox:latest"
@@ -92,6 +93,7 @@ class DockerDaemonProxy:
             else None,
         )["Id"]
         self.docker_client.start(self._daemon_container)
+        register_container(self._daemon_container)
         self.log.write(
             f"Created Docker daemon container {self._daemon_container:.10}\n"
         )
@@ -104,12 +106,14 @@ class DockerDaemonProxy:
         self.log.write(
             f"Destroying Docker daemon container {self._daemon_container:.10}\n"
         )
-        try:
-            if self._daemon_container:
+        if self._daemon_container:
+            try:
                 self.docker_client.remove_container(
                     self._daemon_container,
                     force=True,
                     v=True,
                 )
-        except Exception as _ex:
-            self.log.write(f"Failed to remove Docker daemon container: {_ex}\n")
+            except Exception as _ex:
+                self.log.write(f"Failed to remove Docker daemon container: {_ex}\n")
+            finally:
+                unregister_container(self._daemon_container)

--- a/buildrunner/docker/multiplatform_image_builder.py
+++ b/buildrunner/docker/multiplatform_image_builder.py
@@ -23,6 +23,7 @@ import timeout_decorator
 from python_on_whales import docker
 from retry import retry
 
+from buildrunner.cleanup import register_container, unregister_container
 from buildrunner.config import BuildRunnerConfig
 from buildrunner.config.models import MP_LOCAL_REGISTRY
 from buildrunner.docker import get_dockerfile
@@ -166,6 +167,7 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
             if self._docker_registry:
                 image = f"{self._docker_registry}/{image}"
             container = docker.run(image, detach=True, publish_all=True)
+            register_container(container.name)
             ports = container.network_settings.ports
 
             # If any assert fails something changed in the registry image and we need to update this code
@@ -199,6 +201,8 @@ class MultiplatformImageBuilder:  # pylint: disable=too-many-instance-attributes
                 LOGGER.error(
                     f"Failed to stop and remove local registry {self._mp_registry_info.name}: {err}"
                 )
+            finally:
+                unregister_container(self._mp_registry_info.name)
             self._local_registry_is_running = False
         else:
             LOGGER.warning("Local registry is not running when attempting to stop it")

--- a/buildrunner/docker/runner.py
+++ b/buildrunner/docker/runner.py
@@ -26,6 +26,7 @@ import docker.errors
 import timeout_decorator
 
 from buildrunner import BuildRunnerConfig
+from buildrunner.cleanup import register_container, unregister_container
 from buildrunner.docker import (
     new_client,
     force_remove_container,
@@ -296,6 +297,7 @@ class DockerRunner:
         # start the container
         self.container = self.docker_client.create_container(self.image_name, **kwargs)
         self.docker_client.start(self.container["Id"])
+        register_container(self.container["Id"])
 
         # run any supplied provisioners
         if provisioners:
@@ -361,6 +363,8 @@ class DockerRunner:
                 print(
                     f'Unable to delete docker container with id "{self.container["Id"]}"'
                 )
+            finally:
+                unregister_container(self.container["Id"])
 
         self.container = None
 

--- a/buildrunner/sshagent/__init__.py
+++ b/buildrunner/sshagent/__init__.py
@@ -25,10 +25,10 @@ from paramiko import (
 )
 from paramiko.agent import AgentSSH
 from paramiko.common import io_sleep
-from paramiko.util import asbytes
 from paramiko.message import Message
 
 import buildrunner.docker.builder
+from buildrunner.cleanup import register_container, unregister_container
 from buildrunner.errors import (
     BuildRunnerConfigurationError,
     BuildRunnerProcessingError,
@@ -152,6 +152,7 @@ class DockerSSHAgentProxy:
         self.docker_client.start(
             self._ssh_agent_container,
         )
+        register_container(self._ssh_agent_container)
         self.log.write(f"Created ssh-agent container {self._ssh_agent_container:.10}\n")
 
         _ssh_host = "localhost"
@@ -268,6 +269,8 @@ class DockerSSHAgentProxy:
                 )
             except Exception as _ex:
                 self.log.write(f"Error destroying ssh-agent container: {_ex}\n")
+            finally:
+                unregister_container(self._ssh_agent_container)
 
     def get_ssh_agent_image(self):
         """
@@ -420,7 +423,7 @@ class CustomAgentConnectionThread(threading.Thread):
         """
         Send a reply back to the upstream agent.
         """
-        raw_msg = asbytes(msg)
+        raw_msg = msg.asbytes()
         length = struct.pack(">I", len(raw_msg))
         self._remote_channel.send(length + raw_msg)
 

--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -18,6 +18,7 @@ import uuid
 import python_on_whales
 
 import buildrunner.docker
+from buildrunner.cleanup import register_container, unregister_container
 from buildrunner.config import BuildRunnerConfig
 from buildrunner.config.models_step import RunAndServicesBase, StepRun, Service
 from buildrunner.docker.daemon import DockerDaemonProxy
@@ -116,6 +117,7 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             self._docker_client.start(
                 self._source_container,
             )
+            register_container(self._source_container)
             self.step_runner.log.info(
                 f"Created source container {self._source_container:.10}"
             )
@@ -1206,11 +1208,16 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             self.step_runner.log.info(
                 f"Destroying source container {self._source_container:.10}"
             )
-            self._docker_client.remove_container(
-                self._source_container,
-                force=True,
-                v=True,
-            )
+            try:
+                self._docker_client.remove_container(
+                    self._source_container,
+                    force=True,
+                    v=True,
+                )
+            except Exception as _ex:
+                self.step_runner.log.info(f"Error removing source container: {_ex}")
+            finally:
+                unregister_container(self._source_container)
 
         for image in self.images_to_remove:
             python_on_whales.docker.image.remove(image, force=True)

--- a/docs/common-issues.rst
+++ b/docs/common-issues.rst
@@ -70,6 +70,60 @@ A couple of potential solutions are:
 
 Neither of these solutions are perfect, but both significantly shrink the chance of encountering the race condition.
 
+Container cleanup on build abort
+#################################
+
+When a build is interrupted (e.g. a CI system sends ``SIGTERM`` to abort a superseded PR build),
+buildrunner needs to clean up the Docker containers it started. Without proper cleanup, containers
+running ``/usr/sbin/init`` (systemd) or ``/run.sh`` (sshd) will remain running indefinitely,
+accumulating over time and consuming disk, memory, and network resources on the build agent.
+
+How cleanup works
+=================
+
+Buildrunner tracks every Docker container it starts in a global registry. Cleanup happens in two ways:
+
+1. **Normal exit**: Each build step has a ``finally`` block that calls ``cleanup()`` on all containers
+   it created (the build container, service containers, SSH agent, Docker daemon proxy, and source
+   container). These ``finally`` blocks run on normal completion, exceptions, and ``sys.exit()``.
+
+2. **Signal-based cleanup**: A ``SIGTERM`` or ``SIGINT`` handler is installed at startup. When the
+   signal is received, the handler force-removes all registered containers via
+   ``docker remove --force`` and then calls ``os._exit()`` to terminate immediately. This covers
+   the case where the process is killed externally before ``finally`` blocks can run.
+
+The signal handler uses ``os._exit()`` (not ``sys.exit()``) to avoid triggering ``finally`` blocks
+after cleanup has already been performed, which would cause race conditions and double-removal
+attempts.
+
+Limitations
+===========
+
+- ``SIGKILL`` (``kill -9``) cannot be caught by any handler. If the process is killed with
+  ``SIGKILL``, containers will be orphaned. CI systems should always send ``SIGTERM`` first and
+  allow time for cleanup before escalating to ``SIGKILL``.
+
+- Containers started *inside* a buildrunner container (e.g. via testcontainers or direct
+  ``docker run`` commands within a build step) are not tracked by the cleanup registry. These
+  child containers must be cleaned up by the code that started them.
+
+- If the Docker daemon is unreachable when the signal handler runs, cleanup will fail silently
+  and a warning will be printed to stderr.
+
+Diagnosing orphaned containers
+==============================
+
+Containers started by buildrunner are labeled with the labels passed via ``--container-labels``.
+To find orphaned buildrunner containers on an agent:
+
+.. code:: bash
+
+    # List all containers with buildrunner labels (adjust label key to match your setup)
+    docker ps -a --filter label=com.example.build.source=buildrunner
+
+    # Force-remove all orphaned buildrunner containers
+    docker ps -q --filter label=com.example.build.source=buildrunner | xargs -r docker rm -f
+
 Utilizing multi-platform base images
 ####################################
 

--- a/docs/global-configuration.rst
+++ b/docs/global-configuration.rst
@@ -132,8 +132,8 @@ they are used when put into the global configuration file:
     enabled: false
     # Only trivy is currently supported
     scanner: "trivy"
-    # The version of the trivy image to pull
-    version: "latest"
+    # The version of the trivy image to pull (used when 'image' is not set)
+    version: "0.69.3"
     # The local cache directory for the scanner (used if supported by the scanner)
     cache-dir: null
     config:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,130 @@
+"""
+Tests for the buildrunner.cleanup module — signal-handler-based container cleanup.
+"""
+
+from unittest import mock
+
+import pytest
+
+from buildrunner.cleanup import (
+    _force_cleanup_all,
+    _registered_containers,
+    install_signal_handlers,
+    register_container,
+    set_docker_client,
+    unregister_container,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cleanup_state():
+    """Reset cleanup module state before each test."""
+    import buildrunner.cleanup as mod
+
+    mod._registered_containers.clear()
+    mod._docker_client = None
+    mod._cleanup_done = False
+    yield
+    mod._registered_containers.clear()
+    mod._docker_client = None
+    mod._cleanup_done = False
+
+
+class TestRegisterUnregister:
+    def test_register_adds_container(self):
+        register_container("abc123")
+        assert "abc123" in _registered_containers
+
+    def test_register_ignores_duplicates(self):
+        register_container("abc123")
+        register_container("abc123")
+        assert _registered_containers.count("abc123") == 1
+
+    def test_register_ignores_empty(self):
+        register_container("")
+        register_container(None)
+        assert len(_registered_containers) == 0
+
+    def test_unregister_removes_container(self):
+        register_container("abc123")
+        unregister_container("abc123")
+        assert "abc123" not in _registered_containers
+
+    def test_unregister_nonexistent_is_noop(self):
+        unregister_container("nonexistent")
+        # Should not raise
+
+    def test_register_multiple(self):
+        register_container("aaa")
+        register_container("bbb")
+        register_container("ccc")
+        assert len(_registered_containers) == 3
+
+
+class TestForceCleanupAll:
+    def test_removes_all_registered_containers(self):
+        client = mock.MagicMock()
+        set_docker_client(client)
+        register_container("aaa")
+        register_container("bbb")
+
+        _force_cleanup_all()
+
+        assert client.remove_container.call_count == 2
+        client.remove_container.assert_any_call("aaa", force=True, v=True)
+        client.remove_container.assert_any_call("bbb", force=True, v=True)
+
+    def test_only_runs_once(self):
+        client = mock.MagicMock()
+        set_docker_client(client)
+        register_container("aaa")
+
+        _force_cleanup_all()
+        _force_cleanup_all()  # second call should be no-op
+
+        assert client.remove_container.call_count == 1
+
+    def test_no_containers_is_noop(self):
+        client = mock.MagicMock()
+        set_docker_client(client)
+
+        _force_cleanup_all()
+
+        client.remove_container.assert_not_called()
+
+    def test_handles_remove_exception_gracefully(self):
+        client = mock.MagicMock()
+        client.remove_container.side_effect = Exception("container not found")
+        set_docker_client(client)
+        register_container("aaa")
+        register_container("bbb")
+
+        # Should not raise
+        _force_cleanup_all()
+
+        # Should attempt both even if first fails
+        assert client.remove_container.call_count == 2
+
+    def test_creates_client_if_none_set(self):
+        register_container("aaa")
+
+        with mock.patch("buildrunner.cleanup.sys") as mock_sys:
+            mock_sys.stderr = mock.MagicMock()
+            with mock.patch.dict("sys.modules", {"docker": mock.MagicMock()}) as _:
+                import buildrunner.cleanup as mod
+
+                mod._docker_client = None
+                mod._cleanup_done = False
+                # This should try to create a client via docker.from_env()
+                _force_cleanup_all()
+
+
+class TestInstallSignalHandlers:
+    def test_installs_sigterm_handler(self):
+        with mock.patch("buildrunner.cleanup.signal") as mock_signal:
+            with mock.patch("buildrunner.cleanup.atexit") as mock_atexit:
+                install_signal_handlers()
+
+                mock_signal.signal.assert_any_call(mock_signal.SIGTERM, mock.ANY)
+                mock_signal.signal.assert_any_call(mock_signal.SIGINT, mock.ANY)
+                mock_atexit.register.assert_called_once()

--- a/tests/test_config_validation/test_models.py
+++ b/tests/test_config_validation/test_models.py
@@ -14,7 +14,7 @@ from buildrunner.config import models_step
             {
                 "enabled": False,
                 "scanner": "trivy",
-                "version": "latest",
+                "version": "0.69.3",
                 "cache-dir": None,
                 "config": {
                     "timeout": "20m",
@@ -30,7 +30,7 @@ from buildrunner.config import models_step
             {
                 "enabled": True,
                 "scanner": "trivy",
-                "version": "latest",
+                "version": "0.69.3",
                 "cache-dir": None,
                 "config": {
                     "timeout": "20m",

--- a/tests/test_push_security_scan.py
+++ b/tests/test_push_security_scan.py
@@ -359,7 +359,7 @@ def test__security_scan_trivy(
     }
 
     docker_runner_mock.ImageConfig.assert_called_once_with(
-        "registry1/aquasec/trivy:latest",
+        "registry1/aquasec/trivy:0.69.3",
         pull_image=False,
     )
     docker_runner_mock.assert_called_once_with(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
Adds signal-based container cleanup to prevent orphaned Docker containers when buildrunner is terminated externally (e.g. SIGTERM from a CI system aborting a superseded build).

  Today, buildrunner relies on Python finally blocks to clean up containers. When the process receives SIGTERM, Python's default handler calls os._exit() immediately — finally blocks never execute, and containers running /usr/sbin/init (systemd) or /run.sh (sshd) are left running indefinitely. Over time these accumulate and consume disk, memory, and network resources on build agents.

  This change:
  - Adds a global container registry that tracks every container buildrunner starts
  - Installs SIGTERM/SIGINT handlers that force-remove all registered containers before exiting
  - Registers an atexit hook as a safety net for normal exits where cleanup might be missed
  - Covers all 5 container creation paths: build containers, service containers, SSH agent, Docker daemon proxy, source containers, and the multiplatform registry container

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->
Fixes orphaned Docker containers, overlay mounts, and virtual network interfaces accumulating on build agents when builds are aborted or superseded.

### Previous Behavior
<!-- Remove this section if not relevant -->
When buildrunner received SIGTERM (e.g. CI system aborting a build), the process terminated immediately without cleaning up Docker containers. Containers running systemd or sshd continued running indefinitely. Each aborted build left behind 2+ containers, associated overlay mounts, and veth interfaces.

### New Behavior
<!-- Remove this section if not relevant -->
When buildrunner receives SIGTERM or SIGINT, a signal handler force-removes all Docker containers started by this buildrunner process, then exits. The handler is signal-safe: no locks, no logging (uses stderr), and uses os._exit() to avoid racing with finally blocks. On normal completion, containers are unregistered as they're cleaned up through the existing code paths, so the signal handler has nothing to do.

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base ``version`` in [pyproject.toml](../pyproject.toml) (if appropriate).

