### PR TITLE
XENG-10487 Fix VCS detection failure exit code

### DIFF
--- a/buildrunner/__init__.py
+++ b/buildrunner/__init__.py
@@ -115,10 +115,10 @@ class BuildRunner:
             self.log.write(
                 f"{err}\nPlease verify you have a VCS set up for this project.\n"
             )
-            sys.exit()
+            sys.exit(1)
         except VCSMissingRevision as err:
             self.log.write(f"{err}\nMake sure you have at least one commit.\n")
-            sys.exit()
+            sys.exit(1)
 
         # load global configuration - must come *after* VCS detection
         BuildRunnerConfig.initialize_instance(


### PR DESCRIPTION
sys.exit() without argument exits 0 (success). Both VCSUnsupported and VCSMissingRevision errors now exit with code 1 to signal failure. Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>