### PR TITLE
Fix netcat wait_for hang and ARM incompatibility in run steps

### DIFF
--- a/buildrunner/steprunner/tasks/run.py
+++ b/buildrunner/steprunner/tasks/run.py
@@ -46,8 +46,8 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
 
     # Lightweight docker image for artifact management
     ARTIFACT_LISTER_DOCKER_IMAGE = "ubuntu:19.04"
-    # Lightweight docker image for running nc
-    NC_DOCKER_IMAGE = "subfuzion/netcat:latest"
+    # Lightweight, multiplatform docker image for running nc
+    NC_DOCKER_IMAGE = "busybox:latest"
 
     # Default to 10 min when waiting for ports to be opened
     WAIT_FOR_DEFAULT_TIMEOUT = 600
@@ -766,9 +766,10 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
             # Linux can talk to containers directly, but mac and other OSes cannot
             # See https://github.com/docker/for-mac/issues/155 for more info for mac
             nc_tester = None
+            nc_image_name = f"{BuildRunnerConfig.get_instance().global_config.docker_registry}/{self.NC_DOCKER_IMAGE}"
             try:
                 image_config = DockerRunner.ImageConfig(
-                    f"{BuildRunnerConfig.get_instance().global_config.docker_registry}/{self.NC_DOCKER_IMAGE}",
+                    nc_image_name,
                     pull_image=False,
                 )
                 nc_tester = DockerRunner(
@@ -778,13 +779,29 @@ class RunBuildStepRunnerTask(BuildStepRunnerTask):
                 )
                 nc_tester.start(
                     # The shell is the command
-                    shell=f"-n -z {ipaddr} {port}",
+                    shell=f"nc -n -z {ipaddr} {port}",
                     network=self.step_runner.network_name,
                 )
 
                 nc_tester.attach_until_finished()
                 exit_code = nc_tester.exit_code
-                socket_open = exit_code is not None and not exit_code
+                # nc only ever exits 0 (open) or 1 (closed/timed out). Any other
+                # exit code (e.g. 255 for "exec format error" on architecture
+                # mismatches) means nc never actually ran, so fail fast instead
+                # of retrying until the overall timeout is reached.
+                if exit_code not in (0, 1):
+                    nc_output = (
+                        nc_tester.docker_client.logs(nc_tester.container["Id"])
+                        .decode("utf-8", "replace")
+                        .strip()
+                    )
+                    raise BuildRunnerProcessingError(
+                        f"Unexpected exit code {exit_code} from nc image {nc_image_name} while checking "
+                        f"port {port} in container {name}; nc only exits 0 or 1 when it actually runs, "
+                        f"so this likely means the image failed to execute on this platform/architecture. "
+                        f"Container output: {nc_output or '<empty>'}"
+                    )
+                socket_open = exit_code == 0
             finally:
                 if nc_tester:
                     nc_tester.cleanup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "buildrunner"
-version = "3.25"
+version = "3.26"
 description = "Docker-based build tool"
 readme = "README.rst"
 requires-python = ">=3.9"

--- a/tests/test_run_task_wait.py
+++ b/tests/test_run_task_wait.py
@@ -1,0 +1,104 @@
+from unittest import mock
+
+import pytest
+
+from buildrunner import BuildRunnerConfig
+from buildrunner.errors import BuildRunnerProcessingError
+from buildrunner.steprunner.tasks.run import RunBuildStepRunnerTask
+
+
+@pytest.fixture(name="initialize_config", autouse=True)
+def fixture_initialize_config(tmp_path):
+    buildrunner_path = tmp_path / "buildrunner.yaml"
+    buildrunner_path.write_text("steps: {'step1': {}}")
+    BuildRunnerConfig.initialize_instance(
+        build_id="123",
+        vcs=None,
+        build_dir=str(tmp_path),
+        global_config_file=None,
+        run_config_file=str(buildrunner_path),
+        build_time=0,
+        build_number=1,
+        push=False,
+        steps_to_run=None,
+        log_generated_files=False,
+        global_config_overrides={},
+        platform=None,
+    )
+
+
+@pytest.fixture(name="task")
+def fixture_task():
+    """
+    A RunBuildStepRunnerTask with __init__ skipped, since it otherwise
+    requires a live docker daemon connection. Only the attributes used by
+    wait() are populated.
+    """
+    task = object.__new__(RunBuildStepRunnerTask)
+    task._docker_client = mock.MagicMock()
+    task._docker_client.inspect_container.return_value = {
+        "NetworkSettings": {"IPAddress": "10.0.0.5"},
+        "State": {"Status": "running"},
+    }
+    task.step_runner = mock.MagicMock()
+    task.step_runner.network_name = None
+    return task
+
+
+def _mock_docker_runner_class(exit_code, container_id="abc123", log_output=b""):
+    mock_class = mock.MagicMock()
+    nc_tester = mock_class.return_value
+    nc_tester.exit_code = exit_code
+    nc_tester.container = {"Id": container_id}
+    nc_tester.docker_client.logs.return_value = log_output
+    return mock_class
+
+
+def test_wait_uses_busybox_nc_and_succeeds_on_open_port(task):
+    mock_class = _mock_docker_runner_class(exit_code=0)
+    with mock.patch("buildrunner.steprunner.tasks.run.DockerRunner", mock_class):
+        task.wait("mycontainer", 1234)
+
+    nc_tester = mock_class.return_value
+    _, start_kwargs = nc_tester.start.call_args
+    assert start_kwargs["shell"] == "nc -n -z 10.0.0.5 1234"
+    assert nc_tester.cleanup.called
+
+    image_config_args, _ = mock_class.ImageConfig.call_args
+    assert image_config_args[0].endswith("/busybox:latest")
+
+
+def test_wait_raises_immediately_on_unexpected_exit_code(task):
+    """
+    A non-amd64 host running the (amd64-only) nc image previously used here
+    causes docker to exit with 255 (exec format error) rather than nc's own
+    0/1. That must fail fast instead of retrying until the timeout.
+    """
+    mock_class = _mock_docker_runner_class(
+        exit_code=255,
+        log_output=b"standard_init_linux.go:228: exec user process caused: exec format error\n",
+    )
+    with mock.patch("buildrunner.steprunner.tasks.run.DockerRunner", mock_class):
+        with pytest.raises(BuildRunnerProcessingError) as exc_info:
+            task.wait("mycontainer", 1234)
+
+    assert "Unexpected exit code 255" in str(exc_info.value)
+    assert "exec format error" in str(exc_info.value)
+    assert mock_class.return_value.cleanup.called
+
+
+def test_wait_retries_on_closed_port_then_succeeds(task):
+    mock_class = mock.MagicMock()
+    nc_testers = [mock.MagicMock(), mock.MagicMock()]
+    for nc_tester in nc_testers:
+        nc_tester.container = {"Id": "abc123"}
+    nc_testers[0].exit_code = 1
+    nc_testers[1].exit_code = 0
+    mock_class.side_effect = nc_testers
+
+    with mock.patch("buildrunner.steprunner.tasks.run.DockerRunner", mock_class):
+        with mock.patch("time.sleep"):
+            task.wait("mycontainer", 1234)
+
+    assert mock_class.call_count == 2
+    assert all(nc_tester.cleanup.called for nc_tester in nc_testers)

--- a/uv.lock
+++ b/uv.lock
@@ -105,7 +105,7 @@ wheels = [
 
 [[package]]
 name = "buildrunner"
-version = "3.25"
+version = "3.26"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
subfuzion/netcat is amd64-only and silently hangs the port-wait loop forever on ARM since exec format error (exit 255) was treated the same as "port not open yet". Switch to multiplatform busybox:latest, prepend the nc command, and fail fast on any exit code other than nc's own 0/1, surfacing the container's actual output in the error.

<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base ``version`` in [pyproject.toml](../pyproject.toml) (if appropriate).

