### PR TITLE
Bump stale GitHub Actions to fix deprecated save-state warning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         - '3.12'
         - '3.13'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
@@ -35,12 +35,12 @@ jobs:
       run: uv run pre-commit run --all-files
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: linux/amd64,linux/arm64
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Test with pytest
       # Create the ssh key file once for all testing
@@ -64,7 +64,7 @@ jobs:
     outputs:
       current-version: ${{ steps.version-number.outputs.CURRENT_VERSION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Fetch all history instead of the latest commit
           fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, get-version]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Fetch all history instead of the latest commit
           fetch-depth: 0
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         # Fetch all history instead of the latest commit
         fetch-depth: 0
@@ -123,28 +123,28 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, get-version]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         # Fetch all history instead of the latest commit
         fetch-depth: 0
     - name: Docker Tags
       id: docker_tags
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         images: ghcr.io/adobe/buildrunner
         tags: |
           latest
           ${{ needs.get-version.outputs.current-version }}
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: linux/amd64,linux/arm64
     # Buildx is used to build multi-platform images
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
     # Login to the docker registry
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       # Only login if this a push to main
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       with:
@@ -152,7 +152,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and Push Image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: .
         # Only push images if this is a push to main


### PR DESCRIPTION
actions/checkout@v2 and docker/*@v1-v3 use an old @actions/toolkit version that still emits the deprecated save-state/set-output commands. Bump to checkout@v4, setup-qemu-action@v3, setup-buildx-action@v3, metadata-action@v5, login-action@v3, and build-push-action@v6, all of which use Environment Files instead.

<!--- Provide a general summary of your changes in the Title above -->

### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->

### What issues does this PR fix or reference?
<!-- Remove this section if not relevant -->

### Previous Behavior
<!-- Remove this section if not relevant -->

### New Behavior
<!-- Remove this section if not relevant -->

### Merge requirements satisfied?
- [x] I have updated the documentation or no documentation changes are required.
- [x] I have added tests to cover my changes.
- [x] I have updated the base ``version`` in [pyproject.toml](../pyproject.toml) (if appropriate).

